### PR TITLE
fix error with unique album constraint

### DIFF
--- a/src/modules/albums/albums.service.spec.ts
+++ b/src/modules/albums/albums.service.spec.ts
@@ -57,6 +57,7 @@ describe('AlbumsService', () => {
           provide: TracksService,
           useValue: {
             create: vi.fn(),
+            findOrCreate: vi.fn(),
           },
         },
         {
@@ -193,7 +194,7 @@ describe('AlbumsService', () => {
   describe('findOrCreateAlbumFromExternalId', () => {
     let findAlbumByExternalIdSpy: MockInstance
     let getAlbumSpy: GetAlbumMockInstance
-    let createTracksSpy: MockInstance
+    let findOrCreateSpy: MockInstance
     let createSpy: MockInstance
     let saveSpy: MockInstance
 
@@ -206,7 +207,7 @@ describe('AlbumsService', () => {
         spotifyAlbumsService,
         'getAlbum'
       ) as unknown as GetAlbumMockInstance
-      createTracksSpy = vi.spyOn(tracksService, 'create')
+      findOrCreateSpy = vi.spyOn(tracksService, 'findOrCreate')
       createSpy = vi.spyOn(albumsService, 'create')
       saveSpy = vi.spyOn(albumsRepository, 'save')
     })
@@ -219,7 +220,7 @@ describe('AlbumsService', () => {
 
       findAlbumByExternalIdSpy.mockResolvedValue(foundAlbumMock)
       getAlbumSpy.mockResolvedValue(sdkAlbumMock)
-      createTracksSpy.mockResolvedValue(trackEntitiesMock)
+      findOrCreateSpy.mockResolvedValue(trackEntitiesMock)
       createSpy.mockResolvedValue(albumEntityMock)
       saveSpy.mockResolvedValue(foundAlbumMock)
 
@@ -228,9 +229,8 @@ describe('AlbumsService', () => {
       ).toEqual(foundAlbumMock)
       expect(findAlbumByExternalIdSpy).toHaveBeenCalledWith(externalId)
       expect(getAlbumSpy).toHaveBeenCalledWith(externalId, false)
-      expect(createTracksSpy).toHaveBeenCalledWith(
-        trackEntitiesMock.map(track => track.id),
-        [foundAlbumMock]
+      expect(findOrCreateSpy).toHaveBeenCalledWith(
+        trackEntitiesMock.map(track => track.id)
       )
       expect(saveSpy).toHaveBeenCalledWith(foundAlbumMock)
       expect(createSpy).not.toHaveBeenCalled()
@@ -297,8 +297,8 @@ describe('AlbumsService', () => {
       getAlbumsSpy.mockResolvedValue([sdkAlbumMock])
       findAlbumsByExternalIdsSpy.mockResolvedValue([foundAlbumMock])
       saveSpy.mockResolvedValue(foundAlbumMock)
-      const createTracksSpy = vi
-        .spyOn(tracksService, 'create')
+      const findOrCreateSpy = vi
+        .spyOn(tracksService, 'findOrCreate')
         .mockResolvedValue(trackEntitiesMock)
 
       expect(
@@ -306,9 +306,8 @@ describe('AlbumsService', () => {
       ).toEqual([foundAlbumMock])
       expect(getAlbumsSpy).toHaveBeenCalledWith(externalIds, false)
       expect(findAlbumsByExternalIdsSpy).toHaveBeenCalledWith(externalIds)
-      expect(createTracksSpy).toHaveBeenCalledWith(
-        trackEntitiesMock.map(track => track.id),
-        [foundAlbumMock]
+      expect(findOrCreateSpy).toHaveBeenCalledWith(
+        trackEntitiesMock.map(track => track.id)
       )
       expect(saveSpy).toHaveBeenCalledWith(foundAlbumMock)
       expect(createSpy).not.toHaveBeenCalled()

--- a/src/modules/albums/albums.service.spec.ts
+++ b/src/modules/albums/albums.service.spec.ts
@@ -50,6 +50,7 @@ describe('AlbumsService', () => {
             findAlbumByExternalId: vi.fn(),
             createAlbum: vi.fn(),
             findAlbumsByExternalIds: vi.fn(),
+            save: vi.fn(),
           },
         },
         {
@@ -96,12 +97,14 @@ describe('AlbumsService', () => {
     let findOrCreateImagesSpy: MockInstance
     let findOrCreateArtistsSpy: MockInstance
     let createAlbumSpy: MockInstance
+    let saveSpy: MockInstance
     let createTracksSpy: MockInstance
 
     beforeEach(() => {
       findOrCreateImagesSpy = vi.spyOn(imagesService, 'findOrCreate')
       findOrCreateArtistsSpy = vi.spyOn(artistsService, 'findOrCreate')
       createAlbumSpy = vi.spyOn(albumsRepository, 'createAlbum')
+      saveSpy = vi.spyOn(albumsRepository, 'save')
       createTracksSpy = vi.spyOn(tracksService, 'create')
     })
 
@@ -109,6 +112,7 @@ describe('AlbumsService', () => {
       findOrCreateImagesSpy.mockResolvedValue(imagesMock)
       findOrCreateArtistsSpy.mockResolvedValue(artistEntitiesMock)
       createTracksSpy.mockResolvedValue(trackEntitiesMock)
+      saveSpy.mockReturnValue(albumEntityMock)
       createAlbumSpy.mockReturnValue(albumEntityMock)
 
       expect(await albumsService.create(sdkAlbumMock)).toEqual(albumEntityMock)
@@ -118,6 +122,7 @@ describe('AlbumsService', () => {
         trackEntitiesMock.map(track => track.id),
         [albumEntityMock]
       )
+      expect(saveSpy).toHaveBeenCalledWith(albumEntityMock)
       expect(createAlbumSpy).toHaveBeenCalled()
     })
 
@@ -125,6 +130,7 @@ describe('AlbumsService', () => {
       findOrCreateImagesSpy.mockResolvedValue(imagesMock)
       findOrCreateArtistsSpy.mockResolvedValue(artistEntitiesMock)
       createTracksSpy.mockResolvedValue(trackEntitiesMock)
+      saveSpy.mockReturnValue(albumEntityMock)
       createAlbumSpy.mockReturnValue(albumEntityMock)
 
       expect(
@@ -136,6 +142,7 @@ describe('AlbumsService', () => {
         trackEntitiesMock.map(track => track.id),
         [albumEntityMock]
       )
+      expect(saveSpy).toHaveBeenCalledWith(albumEntityMock)
       expect(createAlbumSpy).toHaveBeenCalled()
     })
   })
@@ -188,6 +195,7 @@ describe('AlbumsService', () => {
     let getAlbumSpy: GetAlbumMockInstance
     let createTracksSpy: MockInstance
     let createSpy: MockInstance
+    let saveSpy: MockInstance
 
     beforeEach(() => {
       findAlbumByExternalIdSpy = vi.spyOn(
@@ -200,6 +208,7 @@ describe('AlbumsService', () => {
       ) as unknown as GetAlbumMockInstance
       createTracksSpy = vi.spyOn(tracksService, 'create')
       createSpy = vi.spyOn(albumsService, 'create')
+      saveSpy = vi.spyOn(albumsRepository, 'save')
     })
 
     test('should create tracks and return found album with tracks', async () => {
@@ -212,6 +221,7 @@ describe('AlbumsService', () => {
       getAlbumSpy.mockResolvedValue(sdkAlbumMock)
       createTracksSpy.mockResolvedValue(trackEntitiesMock)
       createSpy.mockResolvedValue(albumEntityMock)
+      saveSpy.mockResolvedValue(foundAlbumMock)
 
       expect(
         await albumsService.findOrCreateAlbumFromExternalId(externalId)
@@ -222,6 +232,7 @@ describe('AlbumsService', () => {
         trackEntitiesMock.map(track => track.id),
         [foundAlbumMock]
       )
+      expect(saveSpy).toHaveBeenCalledWith(foundAlbumMock)
       expect(createSpy).not.toHaveBeenCalled()
     })
 
@@ -242,6 +253,7 @@ describe('AlbumsService', () => {
   describe('findOrCreateAlbumsFromExternalIds', () => {
     let getAlbumsSpy: GetAlbumsMockInstance
     let createSpy: MockInstance
+    let saveSpy: MockInstance
     let findAlbumsByExternalIdsSpy: MockInstance
 
     beforeEach(() => {
@@ -250,6 +262,7 @@ describe('AlbumsService', () => {
         'getAlbums'
       ) as unknown as GetAlbumsMockInstance
       createSpy = vi.spyOn(albumsService, 'create')
+      saveSpy = vi.spyOn(albumsRepository, 'save')
       findAlbumsByExternalIdsSpy = vi.spyOn(
         albumsRepository,
         'findAlbumsByExternalIds'
@@ -283,6 +296,7 @@ describe('AlbumsService', () => {
 
       getAlbumsSpy.mockResolvedValue([sdkAlbumMock])
       findAlbumsByExternalIdsSpy.mockResolvedValue([foundAlbumMock])
+      saveSpy.mockResolvedValue(foundAlbumMock)
       const createTracksSpy = vi
         .spyOn(tracksService, 'create')
         .mockResolvedValue(trackEntitiesMock)
@@ -296,6 +310,7 @@ describe('AlbumsService', () => {
         trackEntitiesMock.map(track => track.id),
         [foundAlbumMock]
       )
+      expect(saveSpy).toHaveBeenCalledWith(foundAlbumMock)
       expect(createSpy).not.toHaveBeenCalled()
     })
 

--- a/src/modules/albums/albums.service.ts
+++ b/src/modules/albums/albums.service.ts
@@ -84,9 +84,8 @@ export class AlbumsService {
     )
 
     if (foundAlbum?.tracks && foundAlbum.tracks.length > 0) {
-      const tracks = await this.tracksService.create(
-        albumToCreate.tracks.items.map(track => track.id),
-        [foundAlbum]
+      const tracks = await this.tracksService.findOrCreate(
+        albumToCreate.tracks.items.map(track => track.id)
       )
 
       foundAlbum.tracks = tracks
@@ -115,9 +114,8 @@ export class AlbumsService {
       )
 
       if (foundAlbum.tracks && foundAlbum.tracks.length > 0 && albumToCreate) {
-        const tracks = await this.tracksService.create(
-          albumToCreate.tracks.items.map(track => track.id),
-          [foundAlbum]
+        const tracks = await this.tracksService.findOrCreate(
+          albumToCreate.tracks.items.map(track => track.id)
         )
 
         const updateAlbumIndex = foundAlbums.findIndex(

--- a/src/modules/albums/albums.service.ts
+++ b/src/modules/albums/albums.service.ts
@@ -50,12 +50,14 @@ export class AlbumsService {
       artists,
     })
 
-    await this.tracksService.create(
+    const trackEntities = await this.tracksService.create(
       tracks.items.map(track => track.id),
       [album]
     )
 
-    return album
+    album.tracks = trackEntities
+
+    return this.albumsRepository.save(album)
   }
 
   public findOrCreate(data: string, artists?: Artist[]): Promise<Album>
@@ -82,11 +84,14 @@ export class AlbumsService {
     )
 
     if (foundAlbum?.tracks && foundAlbum.tracks.length > 0) {
-      await this.tracksService.create(
+      const tracks = await this.tracksService.create(
         albumToCreate.tracks.items.map(track => track.id),
         [foundAlbum]
       )
-      return foundAlbum
+
+      foundAlbum.tracks = tracks
+
+      return this.albumsRepository.save(foundAlbum)
     }
 
     return this.create(albumToCreate, artists)
@@ -110,10 +115,18 @@ export class AlbumsService {
       )
 
       if (foundAlbum.tracks && foundAlbum.tracks.length > 0 && albumToCreate) {
-        await this.tracksService.create(
+        const tracks = await this.tracksService.create(
           albumToCreate.tracks.items.map(track => track.id),
           [foundAlbum]
         )
+
+        const updateAlbumIndex = foundAlbums.findIndex(
+          album => album.externalId === foundAlbum.externalId
+        )
+
+        foundAlbums[updateAlbumIndex].tracks = tracks
+
+        await this.albumsRepository.save(foundAlbums[updateAlbumIndex])
       }
     }
 

--- a/src/modules/tracks/tracks.service.spec.ts
+++ b/src/modules/tracks/tracks.service.spec.ts
@@ -239,11 +239,12 @@ describe('TracksService', () => {
   })
 
   describe('findOrCreateTracksFromExternalIds', () => {
-    const sdkTracks = [sdkTrackMock, sdkTrackMock]
+    const externalIds = sdkTracksMock.map(track => track.id)
     const foundTracks = [trackEntityMock, trackEntityMock]
 
     let findTrackByExternalIdSpy: MockInstance
     let findOrCreateAlbum: MockInstance
+    let getTracksSpy: MockInstance
 
     beforeEach(() => {
       findTrackByExternalIdSpy = vi.spyOn(
@@ -251,21 +252,17 @@ describe('TracksService', () => {
         'findTracksByExternalIds'
       )
       findOrCreateAlbum = vi.spyOn(albumsService, 'findOrCreate')
-    })
-
-    test('should return empty array if no tracks', async () => {
-      expect(await tracksService.findOrCreate([])).toEqual([])
-      expect(findTrackByExternalIdSpy).not.toHaveBeenCalled()
-      expect(findOrCreateAlbum).not.toHaveBeenCalled()
+      getTracksSpy = vi.spyOn(spotifyTracksService, 'getTracks')
     })
 
     test('should find tracks by external ids', async () => {
       findTrackByExternalIdSpy.mockResolvedValue(foundTracks)
 
-      expect(await tracksService.findOrCreate(sdkTracks)).toEqual(foundTracks)
-      expect(findTrackByExternalIdSpy).toHaveBeenCalledWith(
-        sdkTracks.map(track => track.id)
-      )
+      expect(
+        await tracksService.findOrCreateTracksFromExternalIds(externalIds)
+      ).toEqual(foundTracks)
+      expect(findTrackByExternalIdSpy).toHaveBeenCalledWith(externalIds)
+      expect(getTracksSpy).not.toHaveBeenCalled()
       expect(findOrCreateAlbum).not.toHaveBeenCalled()
     })
 
@@ -273,11 +270,13 @@ describe('TracksService', () => {
       findTrackByExternalIdSpy
         .mockResolvedValueOnce([])
         .mockResolvedValue(foundTracks)
+      getTracksSpy.mockResolvedValue(sdkTracksMock)
 
-      expect(await tracksService.findOrCreate(sdkTracks)).toEqual(foundTracks)
-      expect(findTrackByExternalIdSpy).toHaveBeenCalledWith(
-        sdkTracks.map(track => track.id)
-      )
+      expect(
+        await tracksService.findOrCreateTracksFromExternalIds(externalIds)
+      ).toEqual(foundTracks)
+      expect(findTrackByExternalIdSpy).toHaveBeenCalledWith(externalIds)
+      expect(getTracksSpy).toHaveBeenCalledWith(externalIds, false)
       expect(findTrackByExternalIdSpy).toHaveBeenCalledTimes(2)
     })
   })
@@ -297,16 +296,12 @@ describe('TracksService', () => {
       findOrCreateAlbum = vi.spyOn(albumsService, 'findOrCreate')
     })
 
-    test('should return empty array if no tracks', async () => {
-      expect(await tracksService.findOrCreate([])).toEqual([])
-      expect(findTrackByExternalIdSpy).not.toHaveBeenCalled()
-      expect(findOrCreateAlbum).not.toHaveBeenCalled()
-    })
-
     test('should find tracks by external ids', async () => {
       findTrackByExternalIdSpy.mockResolvedValue(foundTracks)
 
-      expect(await tracksService.findOrCreate(sdkTracks)).toEqual(foundTracks)
+      expect(await tracksService.findOrCreateTracksFromDtos(sdkTracks)).toEqual(
+        foundTracks
+      )
       expect(findTrackByExternalIdSpy).toHaveBeenCalledWith(
         sdkTracks.map(track => track.id)
       )
@@ -318,7 +313,9 @@ describe('TracksService', () => {
         .mockResolvedValueOnce([])
         .mockResolvedValue(foundTracks)
 
-      expect(await tracksService.findOrCreate(sdkTracks)).toEqual(foundTracks)
+      expect(await tracksService.findOrCreateTracksFromDtos(sdkTracks)).toEqual(
+        foundTracks
+      )
       expect(findTrackByExternalIdSpy).toHaveBeenCalledWith(
         sdkTracks.map(track => track.id)
       )


### PR DESCRIPTION
- [x] implement `findOrCreate` method with ids in `tracksService`
      needed in:

 `findOrCreateAlbumFromExternalId`
```ts
 if (foundAlbum?.tracks && foundAlbum.tracks.length > 0) {
    const tracks = await this.tracksService.create(
                                            ^^^^^^ => `findOrCreate`
      albumToCreate.tracks.items.map(track => track.id),
      [foundAlbum]
    )
    
    foundAlbum.tracks = tracks
    
    return this.albumsRepository.save(foundAlbum)
  }
```

`findOrCreateAlbumFromExternalId`
```ts
    for (const foundAlbum of foundAlbums) {
      const albumToCreate = fetchedAlbums.find(
        ({ id }) => id === foundAlbum.externalId
      )

      if (foundAlbum.tracks && foundAlbum.tracks.length > 0 && albumToCreate) {
        await this.tracksService.create(
                                 ^^^^^^ => `findOrCreate`
          albumToCreate.tracks.items.map(track => track.id),
          [foundAlbum]
        )
      }
    }
```

- [x] save album with new tracks
```ts
      if (foundAlbum.tracks && foundAlbum.tracks.length > 0 && albumToCreate) {
        await this.tracksService.create(
          albumToCreate.tracks.items.map(track => track.id),
          [foundAlbum]
        )
      }
```

- [x] filter albums before creating tracks
  by externalId and tracks length

