### PR TITLE
refactor(modules/history/service/synchronize): check if `playHistory` is empty before creating

### DIFF
--- a/src/modules/history/history.service.spec.ts
+++ b/src/modules/history/history.service.spec.ts
@@ -155,5 +155,34 @@ describe('HistoryService', () => {
       })
       expect(getRecentlyPlayedTracksSpy).toHaveBeenCalled()
     })
+
+    test('should not create history tracks if latest play history is empty', async () => {
+      const externalId = 'externalId'
+      const playedAt = new Date()
+
+      const lastHistoryTrack = {
+        track: { ...trackEntityMock, externalId },
+        playedAt,
+      }
+
+      const playHistory = Array.from({ length: 3 }).map(() => ({
+        track: { id: externalId },
+        played_at: playedAt.toISOString(),
+      }))
+
+      findLastHistoryTrackByUserSpy.mockResolvedValue(lastHistoryTrack)
+      tokenSpy.mockResolvedValue(accessTokenMock)
+      getRecentlyPlayedTracksSpy.mockResolvedValue({
+        items: playHistory,
+      } as SdkRecentlyPlayedTracksPage)
+
+      await historyService.synchronize(userMock)
+
+      expect(createSpy).not.toHaveBeenCalled()
+      expect(tokenSpy).toHaveBeenCalledWith({
+        refreshToken: userMock.refreshToken,
+      })
+      expect(getRecentlyPlayedTracksSpy).toHaveBeenCalled()
+    })
   })
 })

--- a/src/modules/history/history.service.ts
+++ b/src/modules/history/history.service.ts
@@ -40,7 +40,8 @@ export class HistoryService {
         latestTrackIndex === -1 ? true : index < latestTrackIndex
       )
 
-      await this.historyTracksService.create(latestPlayHistory, user)
+      if (latestPlayHistory.length > 0)
+        await this.historyTracksService.create(latestPlayHistory, user)
     } else await this.historyTracksService.create(playHistory, user)
   }
 }


### PR DESCRIPTION
closes #247 