### PR TITLE
407 refactor items modules

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -113,6 +113,7 @@ module.exports = {
     'unicorn/prefer-top-level-await': 'off',
     'unicorn/no-useless-undefined': 'off',
     'unicorn/throw-new-error': 'off',
+    'unicorn/no-array-method-this-argument': 'off',
     'unicorn/prevent-abbreviations': [
       'error',
       {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,6 @@ services:
       - .env
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
-      - REDIS_DISABLE_COMMANDS=FLUSHDB,FLUSHALL
     ports:
       - '${REDIS_PORT}:6379'
     volumes:

--- a/src/common/mocks/entity-manager.factory.mock.ts
+++ b/src/common/mocks/entity-manager.factory.mock.ts
@@ -4,6 +4,7 @@ export const entityManagerFactoryMock = () =>
   ({
     findOneBy: vi.fn(),
     findBy: vi.fn(),
+    find: vi.fn(),
     update: vi.fn(),
     create: vi.fn(),
     save: vi.fn(),

--- a/src/modules/items/albums/albums.module.ts
+++ b/src/modules/items/albums/albums.module.ts
@@ -1,6 +1,9 @@
 import { Module, forwardRef } from '@nestjs/common'
 import { TypeOrmModule } from '@nestjs/typeorm'
 
+import { ArtistsModule } from '../artists'
+import { ImagesModule } from '../images'
+
 import { Album } from './album.entity'
 import { AlbumsRepository } from './albums.repository'
 import { AlbumsController } from './albums.controller'
@@ -14,6 +17,8 @@ import { SpotifyModule } from '@modules/spotify'
     TypeOrmModule.forFeature([Album]),
     forwardRef(() => TracksModule),
     SpotifyModule,
+    ArtistsModule,
+    ImagesModule,
   ],
   providers: [AlbumsRepository, AlbumsService],
   controllers: [AlbumsController],

--- a/src/modules/items/albums/albums.module.ts
+++ b/src/modules/items/albums/albums.module.ts
@@ -1,21 +1,20 @@
-import { Module, forwardRef } from '@nestjs/common'
+import { Module } from '@nestjs/common'
 import { TypeOrmModule } from '@nestjs/typeorm'
 
-import { ArtistsModule } from '../artists'
-import { ImagesModule } from '../images'
-
 import { Album } from './album.entity'
-import { AlbumsRepository } from './albums.repository'
 import { AlbumsController } from './albums.controller'
+import { AlbumsRepository } from './albums.repository'
 import { AlbumsService } from './albums.service'
 
+import { ImagesModule } from '@modules/items/images'
+import { ArtistsModule } from '@modules/items/artists'
 import { TracksModule } from '@modules/items/tracks'
 import { SpotifyModule } from '@modules/spotify'
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Album]),
-    forwardRef(() => TracksModule),
+    TracksModule,
     SpotifyModule,
     ArtistsModule,
     ImagesModule,

--- a/src/modules/items/albums/albums.service.spec.ts
+++ b/src/modules/items/albums/albums.service.spec.ts
@@ -39,13 +39,13 @@ describe('AlbumsService', () => {
         {
           provide: TracksService,
           useValue: {
-            updateOrCreate: vi.fn(),
+            findOrCreate: vi.fn(),
           },
         },
         {
           provide: ArtistsService,
           useValue: {
-            updateOrCreate: vi.fn(),
+            findOrCreate: vi.fn(),
           },
         },
         {
@@ -67,7 +67,7 @@ describe('AlbumsService', () => {
     moduleRef.close()
   })
 
-  describe('updateOrCreate', () => {
+  describe('findOrCreate', () => {
     const albumsExternalIds = ['id1', 'id2', 'id3']
 
     let sdkAlbumsMock: SdkAlbum[]
@@ -76,9 +76,9 @@ describe('AlbumsService', () => {
     let findBySpy: MockInstance
     let createSpy: MockInstance
     let saveSpy: MockInstance
-    let artistsUpdateOrCreateSpy: MockInstance
+    let artistsFindOrCreateSpy: MockInstance
     let imagesFindOrCreateSpy: MockInstance
-    let tracksUpdateOrCreateSpy: MockInstance
+    let tracksFindOrCreateSpy: MockInstance
 
     beforeEach(() => {
       sdkAlbumsMock = Array.from({ length: 3 }, (_, index) => ({
@@ -101,16 +101,16 @@ describe('AlbumsService', () => {
       findBySpy = vi.spyOn(entityManagerMock, 'findBy')
       createSpy = vi.spyOn(entityManagerMock, 'create')
       saveSpy = vi.spyOn(entityManagerMock, 'save')
-      artistsUpdateOrCreateSpy = vi.spyOn(artistsService, 'updateOrCreate')
+      artistsFindOrCreateSpy = vi.spyOn(artistsService, 'findOrCreate')
       imagesFindOrCreateSpy = vi.spyOn(imagesService, 'findOrCreate')
-      tracksUpdateOrCreateSpy = vi.spyOn(tracksService, 'updateOrCreate')
+      tracksFindOrCreateSpy = vi.spyOn(tracksService, 'findOrCreate')
     })
 
     test('should find all albums and does not create any', async () => {
       findBySpy.mockResolvedValue(albumsMock)
 
       expect(
-        await albumsService.updateOrCreate(sdkAlbumsMock, entityManagerMock)
+        await albumsService.findOrCreate(sdkAlbumsMock, entityManagerMock)
       ).toEqual(albumsMock)
 
       expect(findBySpy).toHaveBeenCalledWith(Album, {
@@ -118,9 +118,9 @@ describe('AlbumsService', () => {
       })
       expect(createSpy).not.toHaveBeenCalled()
       expect(saveSpy).not.toHaveBeenCalled()
-      expect(artistsUpdateOrCreateSpy).not.toHaveBeenCalled()
+      expect(artistsFindOrCreateSpy).not.toHaveBeenCalled()
       expect(imagesFindOrCreateSpy).not.toHaveBeenCalled()
-      expect(tracksUpdateOrCreateSpy).not.toHaveBeenCalled()
+      expect(tracksFindOrCreateSpy).not.toHaveBeenCalled()
     })
 
     test('should not find any albums and create all', async () => {
@@ -131,12 +131,12 @@ describe('AlbumsService', () => {
       saveSpy.mockImplementation(({ externalId }) =>
         albumsMock.find(album => album.externalId === externalId)
       )
-      artistsUpdateOrCreateSpy.mockResolvedValue(artistEntitiesMock)
+      artistsFindOrCreateSpy.mockResolvedValue(artistEntitiesMock)
       imagesFindOrCreateSpy.mockResolvedValue(imagesMock)
-      tracksUpdateOrCreateSpy.mockResolvedValue(trackEntitiesMock)
+      tracksFindOrCreateSpy.mockResolvedValue(trackEntitiesMock)
 
       expect(
-        await albumsService.updateOrCreate(sdkAlbumsMock, entityManagerMock)
+        await albumsService.findOrCreate(sdkAlbumsMock, entityManagerMock)
       ).toEqual(albumsMock)
 
       expect(findBySpy).toHaveBeenCalledWith(Album, {
@@ -146,22 +146,22 @@ describe('AlbumsService', () => {
       expect(createSpy).toHaveBeenCalledTimes(3)
       expect(saveSpy).toHaveBeenCalledWith(expect.anything())
       expect(saveSpy).toHaveBeenCalledTimes(6)
-      expect(artistsUpdateOrCreateSpy).toHaveBeenCalledWith(
+      expect(artistsFindOrCreateSpy).toHaveBeenCalledWith(
         sdkArtistsMock,
         entityManagerMock
       )
-      expect(artistsUpdateOrCreateSpy).toHaveBeenCalledTimes(3)
+      expect(artistsFindOrCreateSpy).toHaveBeenCalledTimes(3)
       expect(imagesFindOrCreateSpy).toHaveBeenCalledWith(
         sdkImagesMock,
         entityManagerMock
       )
       expect(imagesFindOrCreateSpy).toHaveBeenCalledTimes(3)
-      expect(tracksUpdateOrCreateSpy).toHaveBeenCalledWith(
+      expect(tracksFindOrCreateSpy).toHaveBeenCalledWith(
         sdkTracksMock,
         entityManagerMock,
         albumsMock[2]
       )
-      expect(tracksUpdateOrCreateSpy).toHaveBeenCalledTimes(3)
+      expect(tracksFindOrCreateSpy).toHaveBeenCalledTimes(3)
     })
 
     test('should find some albums and create the rest', async () => {
@@ -174,7 +174,7 @@ describe('AlbumsService', () => {
       saveSpy.mockResolvedValue(albumsMock[2])
 
       expect(
-        await albumsService.updateOrCreate(sdkAlbumsMock, entityManagerMock)
+        await albumsService.findOrCreate(sdkAlbumsMock, entityManagerMock)
       ).toEqual(albumsMock)
 
       expect(findBySpy).toHaveBeenCalledWith(Album, {
@@ -183,22 +183,22 @@ describe('AlbumsService', () => {
       expect(createSpy).toHaveBeenCalledWith(Album, expect.anything())
       expect(createSpy).toHaveBeenCalledTimes(1)
       expect(saveSpy).toHaveBeenCalledWith(albumsMock[2])
-      expect(artistsUpdateOrCreateSpy).toHaveBeenCalledWith(
+      expect(artistsFindOrCreateSpy).toHaveBeenCalledWith(
         sdkArtistsMock,
         entityManagerMock
       )
-      expect(artistsUpdateOrCreateSpy).toHaveBeenCalledTimes(1)
+      expect(artistsFindOrCreateSpy).toHaveBeenCalledTimes(1)
       expect(imagesFindOrCreateSpy).toHaveBeenCalledWith(
         sdkImagesMock,
         entityManagerMock
       )
       expect(imagesFindOrCreateSpy).toHaveBeenCalledTimes(1)
-      expect(tracksUpdateOrCreateSpy).toHaveBeenCalledWith(
+      expect(tracksFindOrCreateSpy).toHaveBeenCalledWith(
         sdkTracksMock,
         entityManagerMock,
         albumsMock[2]
       )
-      expect(tracksUpdateOrCreateSpy).toHaveBeenCalledTimes(1)
+      expect(tracksFindOrCreateSpy).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/modules/items/albums/albums.service.spec.ts
+++ b/src/modules/items/albums/albums.service.spec.ts
@@ -1,31 +1,25 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { Page } from '@spotify/web-api-ts-sdk'
-import { DataSource, EntityManager, In, UpdateResult } from 'typeorm'
+import { EntityManager, In } from 'typeorm'
 import { MockInstance } from 'vitest'
-import { mock } from 'vitest-mock-extended'
 
 import { Album } from './album.entity'
 import { AlbumsService } from './albums.service'
 
 import {
   albumEntityMock,
-  albumsEntitiesMock,
   artistEntitiesMock,
   entityManagerFactoryMock,
   imagesMock,
-  sdkAlbumMock,
-  sdkAlbumsMock,
   sdkArtistsMock,
   sdkImagesMock,
   sdkSimplifiedAlbumMock,
   sdkTracksMock,
   trackEntitiesMock,
-  transactionFactoryMock,
 } from '@common/mocks'
-import { EntityManagerCreateMockInstance } from '@common/types/mocks'
 import { SdkAlbum, SdkTrack } from '@common/types/spotify'
-import { Artist, ArtistsService } from '@modules/items/artists'
-import { Image, ImagesService } from '@modules/items/images'
+import { ArtistsService } from '@modules/items/artists'
+import { ImagesService } from '@modules/items/images'
 import { TracksService } from '@modules/items/tracks'
 
 describe('AlbumsService', () => {
@@ -42,12 +36,6 @@ describe('AlbumsService', () => {
     moduleRef = await Test.createTestingModule({
       providers: [
         AlbumsService,
-        {
-          provide: DataSource,
-          useValue: {
-            transaction: transactionFactoryMock(entityManagerMock),
-          },
-        },
         {
           provide: TracksService,
           useValue: {
@@ -80,245 +68,137 @@ describe('AlbumsService', () => {
   })
 
   describe('updateOrCreate', () => {
-    describe('updateOrCreateOne', () => {
-      let findOneBySpy: MockInstance
-      let tracksUpdateOrCreate: MockInstance
+    const albumsExternalIds = ['id1', 'id2', 'id3']
 
-      beforeEach(() => {
-        findOneBySpy = vi.spyOn(entityManagerMock, 'findOneBy')
-        tracksUpdateOrCreate = vi.spyOn(tracksService, 'updateOrCreate')
-      })
+    let sdkAlbumsMock: SdkAlbum[]
+    let albumsMock: Album[]
 
-      test('should update album if found', async () => {
-        findOneBySpy.mockResolvedValue(albumEntityMock)
-        const updateSpy = vi
-          .spyOn(entityManagerMock, 'update')
-          .mockResolvedValue(mock<UpdateResult>())
+    let findBySpy: MockInstance
+    let createSpy: MockInstance
+    let saveSpy: MockInstance
+    let artistsUpdateOrCreateSpy: MockInstance
+    let imagesFindOrCreateSpy: MockInstance
+    let tracksUpdateOrCreateSpy: MockInstance
 
-        expect(await albumsService.updateOrCreate(sdkAlbumMock)).toEqual(
-          albumEntityMock
-        )
+    beforeEach(() => {
+      sdkAlbumsMock = Array.from({ length: 3 }, (_, index) => ({
+        ...sdkSimplifiedAlbumMock,
+        id: albumsExternalIds[index],
+        images: sdkImagesMock,
+        artists: sdkArtistsMock,
+        tracks: {
+          items: sdkTracksMock,
+        } as Page<SdkTrack>,
+      }))
+      albumsMock = Array.from({ length: 3 }, (_, index) => ({
+        ...albumEntityMock,
+        externalId: albumsExternalIds[index],
+        images: imagesMock,
+        artists: artistEntitiesMock,
+        tracks: trackEntitiesMock,
+      }))
 
-        expect(findOneBySpy).toHaveBeenCalledWith(Album, {
-          externalId: sdkAlbumMock.id,
-        })
-        expect(findOneBySpy).toHaveBeenCalledTimes(2)
-        expect(updateSpy).toHaveBeenCalledWith(
-          Album,
-          { externalId: sdkAlbumMock.id },
-          {
-            name: sdkAlbumMock.name,
-            externalId: sdkAlbumMock.id,
-            href: sdkAlbumMock.external_urls.spotify,
-            albumType: sdkAlbumMock.album_type,
-            releaseDate: new Date(sdkAlbumMock.release_date),
-            releaseDatePrecision: sdkAlbumMock.release_date_precision,
-            label: sdkAlbumMock.label,
-            copyrights: sdkAlbumMock.copyrights.map(({ text }) => text),
-            genres: sdkAlbumMock.genres,
-            totalTracks: sdkAlbumMock.total_tracks,
-          }
-        )
-        expect(tracksUpdateOrCreate).toHaveBeenCalled()
-      })
-
-      test('should create album if not found', async () => {
-        findOneBySpy.mockResolvedValue(null)
-        const findBySpy = vi
-          .spyOn(entityManagerMock, 'findBy')
-          .mockResolvedValueOnce(imagesMock)
-          .mockResolvedValueOnce(artistEntitiesMock)
-        const createSpy = (
-          vi.spyOn(
-            entityManagerMock,
-            'create'
-          ) as EntityManagerCreateMockInstance
-        ).mockReturnValue(albumEntityMock)
-        const saveSpy = vi
-          .spyOn(entityManagerMock, 'save')
-          .mockResolvedValue(albumEntityMock)
-
-        expect(await albumsService.updateOrCreate(sdkAlbumMock)).toEqual(
-          albumEntityMock
-        )
-
-        expect(findOneBySpy).toHaveBeenCalledWith(Album, {
-          externalId: sdkAlbumMock.id,
-        })
-        expect(findBySpy).toHaveBeenCalledWith(Artist, {
-          externalId: In(sdkArtistsMock.map(({ id }) => id)),
-        })
-        expect(findBySpy).toHaveBeenCalledWith(Image, {
-          url: In(imagesMock.map(({ url }) => url)),
-        })
-        expect(findBySpy).toHaveBeenCalledTimes(2)
-        expect(createSpy).toHaveBeenCalledWith(Album, {
-          name: sdkAlbumMock.name,
-          externalId: sdkAlbumMock.id,
-          href: sdkAlbumMock.external_urls.spotify,
-          albumType: sdkAlbumMock.album_type,
-          releaseDate: new Date(sdkAlbumMock.release_date),
-          releaseDatePrecision: sdkAlbumMock.release_date_precision,
-          totalTracks: sdkAlbumMock.total_tracks,
-          label: sdkAlbumMock.label,
-          copyrights: sdkAlbumMock.copyrights.map(({ text }) => text),
-          genres: sdkAlbumMock.genres,
-          images: imagesMock,
-          artists: artistEntitiesMock,
-        })
-        expect(saveSpy).toHaveBeenCalled()
-        expect(tracksUpdateOrCreate).toHaveBeenCalled()
-      })
+      findBySpy = vi.spyOn(entityManagerMock, 'findBy')
+      createSpy = vi.spyOn(entityManagerMock, 'create')
+      saveSpy = vi.spyOn(entityManagerMock, 'save')
+      artistsUpdateOrCreateSpy = vi.spyOn(artistsService, 'updateOrCreate')
+      imagesFindOrCreateSpy = vi.spyOn(imagesService, 'findOrCreate')
+      tracksUpdateOrCreateSpy = vi.spyOn(tracksService, 'updateOrCreate')
     })
 
-    describe('updateOrCreateMany', () => {
-      test('should update or create many albums', async () => {
-        const updateOrCreateOneSpy = vi
-          .spyOn(albumsService as never, 'updateOrCreateOne')
-          .mockResolvedValue(albumEntityMock)
+    test('should find all albums and does not create any', async () => {
+      findBySpy.mockResolvedValue(albumsMock)
 
-        expect(await albumsService.updateOrCreate(sdkAlbumsMock)).toEqual(
-          albumsEntitiesMock
-        )
+      expect(
+        await albumsService.updateOrCreate(sdkAlbumsMock, entityManagerMock)
+      ).toEqual(albumsMock)
 
-        expect(updateOrCreateOneSpy).toHaveBeenCalledWith(sdkAlbumMock)
-        expect(updateOrCreateOneSpy).toHaveBeenCalledTimes(5)
+      expect(findBySpy).toHaveBeenCalledWith(Album, {
+        externalId: In(albumsExternalIds),
       })
+      expect(createSpy).not.toHaveBeenCalled()
+      expect(saveSpy).not.toHaveBeenCalled()
+      expect(artistsUpdateOrCreateSpy).not.toHaveBeenCalled()
+      expect(imagesFindOrCreateSpy).not.toHaveBeenCalled()
+      expect(tracksUpdateOrCreateSpy).not.toHaveBeenCalled()
     })
 
-    describe('updateOrCreateManyInTransaction', () => {
-      const albumsExternalIds = ['id1', 'id2', 'id3']
+    test('should not find any albums and create all', async () => {
+      findBySpy.mockResolvedValueOnce([])
+      createSpy.mockImplementation((_, { externalId }) =>
+        albumsMock.find(album => album.externalId === externalId)
+      )
+      saveSpy.mockImplementation(({ externalId }) =>
+        albumsMock.find(album => album.externalId === externalId)
+      )
+      artistsUpdateOrCreateSpy.mockResolvedValue(artistEntitiesMock)
+      imagesFindOrCreateSpy.mockResolvedValue(imagesMock)
+      tracksUpdateOrCreateSpy.mockResolvedValue(trackEntitiesMock)
 
-      let sdkAlbumsMock: SdkAlbum[]
-      let albumsMock: Album[]
+      expect(
+        await albumsService.updateOrCreate(sdkAlbumsMock, entityManagerMock)
+      ).toEqual(albumsMock)
 
-      let findBySpy: MockInstance
-      let createSpy: MockInstance
-      let saveSpy: MockInstance
-      let artistsUpdateOrCreateSpy: MockInstance
-      let imagesFindOrCreateSpy: MockInstance
-      let tracksUpdateOrCreateSpy: MockInstance
-
-      beforeEach(() => {
-        sdkAlbumsMock = Array.from({ length: 3 }, (_, index) => ({
-          ...sdkSimplifiedAlbumMock,
-          id: albumsExternalIds[index],
-          images: sdkImagesMock,
-          artists: sdkArtistsMock,
-          tracks: {
-            items: sdkTracksMock,
-          } as Page<SdkTrack>,
-        }))
-        albumsMock = Array.from({ length: 3 }, (_, index) => ({
-          ...albumEntityMock,
-          externalId: albumsExternalIds[index],
-          images: imagesMock,
-          artists: artistEntitiesMock,
-          tracks: trackEntitiesMock,
-        }))
-
-        findBySpy = vi.spyOn(entityManagerMock, 'findBy')
-        createSpy = vi.spyOn(entityManagerMock, 'create')
-        saveSpy = vi.spyOn(entityManagerMock, 'save')
-        artistsUpdateOrCreateSpy = vi.spyOn(artistsService, 'updateOrCreate')
-        imagesFindOrCreateSpy = vi.spyOn(imagesService, 'findOrCreate')
-        tracksUpdateOrCreateSpy = vi.spyOn(tracksService, 'updateOrCreate')
+      expect(findBySpy).toHaveBeenCalledWith(Album, {
+        externalId: In(albumsExternalIds),
       })
+      expect(createSpy).toHaveBeenCalledWith(Album, expect.anything())
+      expect(createSpy).toHaveBeenCalledTimes(3)
+      expect(saveSpy).toHaveBeenCalledWith(expect.anything())
+      expect(saveSpy).toHaveBeenCalledTimes(6)
+      expect(artistsUpdateOrCreateSpy).toHaveBeenCalledWith(
+        sdkArtistsMock,
+        entityManagerMock
+      )
+      expect(artistsUpdateOrCreateSpy).toHaveBeenCalledTimes(3)
+      expect(imagesFindOrCreateSpy).toHaveBeenCalledWith(
+        sdkImagesMock,
+        entityManagerMock
+      )
+      expect(imagesFindOrCreateSpy).toHaveBeenCalledTimes(3)
+      expect(tracksUpdateOrCreateSpy).toHaveBeenCalledWith(
+        sdkTracksMock,
+        entityManagerMock,
+        albumsMock[2]
+      )
+      expect(tracksUpdateOrCreateSpy).toHaveBeenCalledTimes(3)
+    })
 
-      test('should find all albums and does not create any', async () => {
-        findBySpy.mockResolvedValue(albumsMock)
+    test('should find some albums and create the rest', async () => {
+      const foundAlbumsMock = [albumsMock[0], albumsMock[1]]
 
-        expect(
-          await albumsService.updateOrCreate(sdkAlbumsMock, entityManagerMock)
-        ).toEqual(albumsMock)
+      findBySpy.mockResolvedValueOnce(foundAlbumsMock)
+      createSpy.mockImplementation((_, { externalId }) =>
+        albumsMock.find(album => album.externalId === externalId)
+      )
+      saveSpy.mockResolvedValue(albumsMock[2])
 
-        expect(findBySpy).toHaveBeenCalledWith(Album, {
-          externalId: In(albumsExternalIds),
-        })
-        expect(createSpy).not.toHaveBeenCalled()
-        expect(saveSpy).not.toHaveBeenCalled()
-        expect(artistsUpdateOrCreateSpy).not.toHaveBeenCalled()
-        expect(imagesFindOrCreateSpy).not.toHaveBeenCalled()
-        expect(tracksUpdateOrCreateSpy).not.toHaveBeenCalled()
+      expect(
+        await albumsService.updateOrCreate(sdkAlbumsMock, entityManagerMock)
+      ).toEqual(albumsMock)
+
+      expect(findBySpy).toHaveBeenCalledWith(Album, {
+        externalId: In(albumsExternalIds),
       })
-
-      test('should not find any albums and create all', async () => {
-        findBySpy.mockResolvedValueOnce([])
-        createSpy.mockImplementation((_, { externalId }) =>
-          albumsMock.find(album => album.externalId === externalId)
-        )
-        saveSpy.mockImplementation(({ externalId }) =>
-          albumsMock.find(album => album.externalId === externalId)
-        )
-        artistsUpdateOrCreateSpy.mockResolvedValue(artistEntitiesMock)
-        imagesFindOrCreateSpy.mockResolvedValue(imagesMock)
-        tracksUpdateOrCreateSpy.mockResolvedValue(trackEntitiesMock)
-
-        expect(
-          await albumsService.updateOrCreate(sdkAlbumsMock, entityManagerMock)
-        ).toEqual(albumsMock)
-
-        expect(findBySpy).toHaveBeenCalledWith(Album, {
-          externalId: In(albumsExternalIds),
-        })
-        expect(createSpy).toHaveBeenCalledWith(Album, expect.anything())
-        expect(createSpy).toHaveBeenCalledTimes(3)
-        expect(saveSpy).toHaveBeenCalledWith(expect.anything())
-        expect(saveSpy).toHaveBeenCalledTimes(6)
-        expect(artistsUpdateOrCreateSpy).toHaveBeenCalledWith(
-          sdkArtistsMock,
-          entityManagerMock
-        )
-        expect(artistsUpdateOrCreateSpy).toHaveBeenCalledTimes(3)
-        expect(imagesFindOrCreateSpy).toHaveBeenCalledWith(
-          sdkImagesMock,
-          entityManagerMock
-        )
-        expect(imagesFindOrCreateSpy).toHaveBeenCalledTimes(3)
-        expect(tracksUpdateOrCreateSpy).toHaveBeenCalledWith(
-          sdkTracksMock,
-          entityManagerMock,
-          albumsMock[2]
-        )
-        expect(tracksUpdateOrCreateSpy).toHaveBeenCalledTimes(3)
-      })
-
-      test('should find some albums and create the rest', async () => {
-        const foundAlbumsMock = [albumsMock[0], albumsMock[1]]
-
-        findBySpy.mockResolvedValueOnce(foundAlbumsMock)
-        createSpy.mockImplementation((_, { externalId }) =>
-          albumsMock.find(album => album.externalId === externalId)
-        )
-        saveSpy.mockResolvedValue(albumsMock[2])
-
-        expect(
-          await albumsService.updateOrCreate(sdkAlbumsMock, entityManagerMock)
-        ).toEqual(albumsMock)
-
-        expect(findBySpy).toHaveBeenCalledWith(Album, {
-          externalId: In(albumsExternalIds),
-        })
-        expect(createSpy).toHaveBeenCalledWith(Album, expect.anything())
-        expect(createSpy).toHaveBeenCalledTimes(1)
-        expect(saveSpy).toHaveBeenCalledWith(albumsMock[2])
-        expect(artistsUpdateOrCreateSpy).toHaveBeenCalledWith(
-          sdkArtistsMock,
-          entityManagerMock
-        )
-        expect(artistsUpdateOrCreateSpy).toHaveBeenCalledTimes(1)
-        expect(imagesFindOrCreateSpy).toHaveBeenCalledWith(
-          sdkImagesMock,
-          entityManagerMock
-        )
-        expect(imagesFindOrCreateSpy).toHaveBeenCalledTimes(1)
-        expect(tracksUpdateOrCreateSpy).toHaveBeenCalledWith(
-          sdkTracksMock,
-          entityManagerMock,
-          albumsMock[2]
-        )
-        expect(tracksUpdateOrCreateSpy).toHaveBeenCalledTimes(1)
-      })
+      expect(createSpy).toHaveBeenCalledWith(Album, expect.anything())
+      expect(createSpy).toHaveBeenCalledTimes(1)
+      expect(saveSpy).toHaveBeenCalledWith(albumsMock[2])
+      expect(artistsUpdateOrCreateSpy).toHaveBeenCalledWith(
+        sdkArtistsMock,
+        entityManagerMock
+      )
+      expect(artistsUpdateOrCreateSpy).toHaveBeenCalledTimes(1)
+      expect(imagesFindOrCreateSpy).toHaveBeenCalledWith(
+        sdkImagesMock,
+        entityManagerMock
+      )
+      expect(imagesFindOrCreateSpy).toHaveBeenCalledTimes(1)
+      expect(tracksUpdateOrCreateSpy).toHaveBeenCalledWith(
+        sdkTracksMock,
+        entityManagerMock,
+        albumsMock[2]
+      )
+      expect(tracksUpdateOrCreateSpy).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/modules/items/albums/albums.service.spec.ts
+++ b/src/modules/items/albums/albums.service.spec.ts
@@ -1,32 +1,40 @@
 import { Test, TestingModule } from '@nestjs/testing'
-import { MockInstance } from 'vitest'
+import { Page } from '@spotify/web-api-ts-sdk'
 import { DataSource, EntityManager, In, UpdateResult } from 'typeorm'
+import { MockInstance } from 'vitest'
 import { mock } from 'vitest-mock-extended'
 
-import { AlbumsService } from './albums.service'
 import { Album } from './album.entity'
+import { AlbumsService } from './albums.service'
 
-import { TracksService } from '@modules/items/tracks'
 import {
   albumEntityMock,
-  sdkAlbumMock,
-  imagesMock,
-  artistEntitiesMock,
-  sdkArtistsMock,
-  entityManagerFactoryMock,
-  transactionFactoryMock,
-  sdkAlbumsMock,
   albumsEntitiesMock,
+  artistEntitiesMock,
+  entityManagerFactoryMock,
+  imagesMock,
+  sdkAlbumMock,
+  sdkAlbumsMock,
+  sdkArtistsMock,
+  sdkImagesMock,
+  sdkSimplifiedAlbumMock,
+  sdkTracksMock,
+  trackEntitiesMock,
+  transactionFactoryMock,
 } from '@common/mocks'
-import { Artist } from '@modules/items/artists'
 import { EntityManagerCreateMockInstance } from '@common/types/mocks'
-import { Image } from '@modules/items/images'
+import { SdkAlbum, SdkTrack } from '@common/types/spotify'
+import { Artist, ArtistsService } from '@modules/items/artists'
+import { Image, ImagesService } from '@modules/items/images'
+import { TracksService } from '@modules/items/tracks'
 
 describe('AlbumsService', () => {
   let moduleRef: TestingModule
   let entityManagerMock: EntityManager
   let albumsService: AlbumsService
   let tracksService: TracksService
+  let artistsService: ArtistsService
+  let imagesService: ImagesService
 
   beforeEach(async () => {
     entityManagerMock = entityManagerFactoryMock()
@@ -46,11 +54,25 @@ describe('AlbumsService', () => {
             updateOrCreate: vi.fn(),
           },
         },
+        {
+          provide: ArtistsService,
+          useValue: {
+            updateOrCreate: vi.fn(),
+          },
+        },
+        {
+          provide: ImagesService,
+          useValue: {
+            findOrCreate: vi.fn(),
+          },
+        },
       ],
     }).compile()
 
     albumsService = moduleRef.get(AlbumsService)
     tracksService = moduleRef.get(TracksService)
+    artistsService = moduleRef.get(ArtistsService)
+    imagesService = moduleRef.get(ImagesService)
   })
 
   afterEach(() => {
@@ -161,6 +183,141 @@ describe('AlbumsService', () => {
 
         expect(updateOrCreateOneSpy).toHaveBeenCalledWith(sdkAlbumMock)
         expect(updateOrCreateOneSpy).toHaveBeenCalledTimes(5)
+      })
+    })
+
+    describe('updateOrCreateManyInTransaction', () => {
+      const albumsExternalIds = ['id1', 'id2', 'id3']
+
+      let sdkAlbumsMock: SdkAlbum[]
+      let albumsMock: Album[]
+
+      let findBySpy: MockInstance
+      let createSpy: MockInstance
+      let saveSpy: MockInstance
+      let artistsUpdateOrCreateSpy: MockInstance
+      let imagesFindOrCreateSpy: MockInstance
+      let tracksUpdateOrCreateSpy: MockInstance
+
+      beforeEach(() => {
+        sdkAlbumsMock = Array.from({ length: 3 }, (_, index) => ({
+          ...sdkSimplifiedAlbumMock,
+          id: albumsExternalIds[index],
+          images: sdkImagesMock,
+          artists: sdkArtistsMock,
+          tracks: {
+            items: sdkTracksMock,
+          } as Page<SdkTrack>,
+        }))
+        albumsMock = Array.from({ length: 3 }, (_, index) => ({
+          ...albumEntityMock,
+          externalId: albumsExternalIds[index],
+          images: imagesMock,
+          artists: artistEntitiesMock,
+          tracks: trackEntitiesMock,
+        }))
+
+        findBySpy = vi.spyOn(entityManagerMock, 'findBy')
+        createSpy = vi.spyOn(entityManagerMock, 'create')
+        saveSpy = vi.spyOn(entityManagerMock, 'save')
+        artistsUpdateOrCreateSpy = vi.spyOn(artistsService, 'updateOrCreate')
+        imagesFindOrCreateSpy = vi.spyOn(imagesService, 'findOrCreate')
+        tracksUpdateOrCreateSpy = vi.spyOn(tracksService, 'updateOrCreate')
+      })
+
+      test('should find all albums and does not create any', async () => {
+        findBySpy.mockResolvedValue(albumsMock)
+
+        expect(
+          await albumsService.updateOrCreate(sdkAlbumsMock, entityManagerMock)
+        ).toEqual(albumsMock)
+
+        expect(findBySpy).toHaveBeenCalledWith(Album, {
+          externalId: In(albumsExternalIds),
+        })
+        expect(createSpy).not.toHaveBeenCalled()
+        expect(saveSpy).not.toHaveBeenCalled()
+        expect(artistsUpdateOrCreateSpy).not.toHaveBeenCalled()
+        expect(imagesFindOrCreateSpy).not.toHaveBeenCalled()
+        expect(tracksUpdateOrCreateSpy).not.toHaveBeenCalled()
+      })
+
+      test('should not find any albums and create all', async () => {
+        findBySpy.mockResolvedValueOnce([])
+        createSpy.mockImplementation((_, { externalId }) =>
+          albumsMock.find(album => album.externalId === externalId)
+        )
+        saveSpy.mockImplementation(({ externalId }) =>
+          albumsMock.find(album => album.externalId === externalId)
+        )
+        artistsUpdateOrCreateSpy.mockResolvedValue(artistEntitiesMock)
+        imagesFindOrCreateSpy.mockResolvedValue(imagesMock)
+        tracksUpdateOrCreateSpy.mockResolvedValue(trackEntitiesMock)
+
+        expect(
+          await albumsService.updateOrCreate(sdkAlbumsMock, entityManagerMock)
+        ).toEqual(albumsMock)
+
+        expect(findBySpy).toHaveBeenCalledWith(Album, {
+          externalId: In(albumsExternalIds),
+        })
+        expect(createSpy).toHaveBeenCalledWith(Album, expect.anything())
+        expect(createSpy).toHaveBeenCalledTimes(3)
+        expect(saveSpy).toHaveBeenCalledWith(expect.anything())
+        expect(saveSpy).toHaveBeenCalledTimes(6)
+        expect(artistsUpdateOrCreateSpy).toHaveBeenCalledWith(
+          sdkArtistsMock,
+          entityManagerMock
+        )
+        expect(artistsUpdateOrCreateSpy).toHaveBeenCalledTimes(3)
+        expect(imagesFindOrCreateSpy).toHaveBeenCalledWith(
+          sdkImagesMock,
+          entityManagerMock
+        )
+        expect(imagesFindOrCreateSpy).toHaveBeenCalledTimes(3)
+        expect(tracksUpdateOrCreateSpy).toHaveBeenCalledWith(
+          sdkTracksMock,
+          entityManagerMock,
+          albumsMock[2]
+        )
+        expect(tracksUpdateOrCreateSpy).toHaveBeenCalledTimes(3)
+      })
+
+      test('should find some albums and create the rest', async () => {
+        const foundAlbumsMock = [albumsMock[0], albumsMock[1]]
+
+        findBySpy.mockResolvedValueOnce(foundAlbumsMock)
+        createSpy.mockImplementation((_, { externalId }) =>
+          albumsMock.find(album => album.externalId === externalId)
+        )
+        saveSpy.mockResolvedValue(albumsMock[2])
+
+        expect(
+          await albumsService.updateOrCreate(sdkAlbumsMock, entityManagerMock)
+        ).toEqual(albumsMock)
+
+        expect(findBySpy).toHaveBeenCalledWith(Album, {
+          externalId: In(albumsExternalIds),
+        })
+        expect(createSpy).toHaveBeenCalledWith(Album, expect.anything())
+        expect(createSpy).toHaveBeenCalledTimes(1)
+        expect(saveSpy).toHaveBeenCalledWith(albumsMock[2])
+        expect(artistsUpdateOrCreateSpy).toHaveBeenCalledWith(
+          sdkArtistsMock,
+          entityManagerMock
+        )
+        expect(artistsUpdateOrCreateSpy).toHaveBeenCalledTimes(1)
+        expect(imagesFindOrCreateSpy).toHaveBeenCalledWith(
+          sdkImagesMock,
+          entityManagerMock
+        )
+        expect(imagesFindOrCreateSpy).toHaveBeenCalledTimes(1)
+        expect(tracksUpdateOrCreateSpy).toHaveBeenCalledWith(
+          sdkTracksMock,
+          entityManagerMock,
+          albumsMock[2]
+        )
+        expect(tracksUpdateOrCreateSpy).toHaveBeenCalledTimes(1)
       })
     })
   })

--- a/src/modules/items/albums/albums.service.ts
+++ b/src/modules/items/albums/albums.service.ts
@@ -1,123 +1,24 @@
-import { Inject, Injectable, forwardRef } from '@nestjs/common'
-import { DataSource, EntityManager, In } from 'typeorm'
+import { Injectable } from '@nestjs/common'
+import { EntityManager, In } from 'typeorm'
 
-import { CreateAlbum, SdkCreateAlbum } from './dtos'
 import { Album } from './album.entity'
+import { CreateAlbum, SdkCreateAlbum } from './dtos'
 import { ReleaseDatePrecision } from './enums'
 
-import { TracksService } from '@modules/items/tracks/tracks.service'
-import { Artist, ArtistsService } from '@modules/items/artists'
-import { Image, ImagesService } from '@modules/items/images'
 import { removeDuplicates } from '@common/utils'
+import { ArtistsService } from '@modules/items/artists'
+import { ImagesService } from '@modules/items/images'
+import { TracksService } from '@modules/items/tracks/tracks.service'
 
 @Injectable()
 export class AlbumsService {
   constructor(
-    private readonly dataSource: DataSource,
-    @Inject(forwardRef(() => TracksService))
     private readonly tracksService: TracksService,
     private readonly artistsService: ArtistsService,
     private readonly imagesService: ImagesService
   ) {}
 
-  public updateOrCreate(data: SdkCreateAlbum): Promise<Album>
-  public updateOrCreate(
-    data: SdkCreateAlbum[],
-    manager?: EntityManager
-  ): Promise<Album[]>
-
-  async updateOrCreate(
-    data: SdkCreateAlbum | SdkCreateAlbum[],
-    manager?: EntityManager
-  ) {
-    if (Array.isArray(data)) {
-      if (manager) return this.updateOrCreateManyInTransaction(data, manager)
-
-      return this.updateOrCreateMany(data)
-    }
-
-    return this.updateOrCreateOne(data)
-  }
-
-  private async updateOrCreateOne(fetchedAlbum: SdkCreateAlbum) {
-    const {
-      id,
-      name,
-      release_date,
-      release_date_precision,
-      label,
-      copyrights,
-      genres,
-      album_type: albumType,
-      total_tracks: totalTracks,
-      external_urls: { spotify: href },
-      images: fetchedAlbumImages,
-      artists: fetchedAlbumArtists,
-      tracks: fetchedAlbumTracks,
-    } = fetchedAlbum
-
-    const albumToCreate: Omit<CreateAlbum, 'images' | 'artists' | 'tracks'> = {
-      name,
-      externalId: id,
-      href,
-      albumType,
-      releaseDate: new Date(release_date),
-      releaseDatePrecision: release_date_precision as ReleaseDatePrecision,
-      label,
-      copyrights: copyrights.map(({ text }) => text),
-      genres,
-      totalTracks,
-    }
-
-    const createdAlbum = await this.dataSource.transaction(async manager => {
-      const foundAlbum = await manager.findOneBy(Album, { externalId: id })
-
-      if (foundAlbum) {
-        await manager.update(Album, { externalId: id }, albumToCreate)
-
-        const foundCreatedAlbum = await manager.findOneBy(Album, {
-          externalId: id,
-        })
-
-        return foundCreatedAlbum!
-      }
-
-      const images = await manager.findBy(Image, {
-        url: In(fetchedAlbumImages.map(image => image.url)),
-      })
-      const artists = await manager.findBy(Artist, {
-        externalId: In(fetchedAlbumArtists.map(({ id }) => id)),
-      })
-
-      const albumEntity = manager.create(Album, {
-        ...albumToCreate,
-        images,
-        artists,
-      })
-
-      return manager.save(albumEntity)
-    })
-
-    await this.tracksService.updateOrCreate(
-      fetchedAlbumTracks.items.map(track => ({
-        ...track,
-        album: fetchedAlbum,
-      }))
-    )
-
-    return createdAlbum
-  }
-
-  private async updateOrCreateMany(fetchedAlbums: SdkCreateAlbum[]) {
-    return Promise.all(
-      fetchedAlbums.map(album => this.updateOrCreateOne(album))
-    )
-  }
-
-  private async updateOrCreateManyInTransaction(
-    sdkAlbums: SdkCreateAlbum[],
-    manager: EntityManager
-  ) {
+  async updateOrCreate(sdkAlbums: SdkCreateAlbum[], manager: EntityManager) {
     const albumsExternalIds = removeDuplicates(sdkAlbums.map(({ id }) => id))
 
     const foundAlbums = await manager.findBy(Album, {

--- a/src/modules/items/albums/albums.service.ts
+++ b/src/modules/items/albums/albums.service.ts
@@ -1,27 +1,40 @@
 import { Inject, Injectable, forwardRef } from '@nestjs/common'
-import { DataSource, In } from 'typeorm'
+import { DataSource, EntityManager, In } from 'typeorm'
 
 import { CreateAlbum, SdkCreateAlbum } from './dtos'
 import { Album } from './album.entity'
 import { ReleaseDatePrecision } from './enums'
 
 import { TracksService } from '@modules/items/tracks/tracks.service'
-import { Artist } from '@modules/items/artists'
-import { Image } from '@modules/items/images'
+import { Artist, ArtistsService } from '@modules/items/artists'
+import { Image, ImagesService } from '@modules/items/images'
+import { removeDuplicates } from '@common/utils'
 
 @Injectable()
 export class AlbumsService {
   constructor(
     private readonly dataSource: DataSource,
     @Inject(forwardRef(() => TracksService))
-    private readonly tracksService: TracksService
+    private readonly tracksService: TracksService,
+    private readonly artistsService: ArtistsService,
+    private readonly imagesService: ImagesService
   ) {}
 
   public updateOrCreate(data: SdkCreateAlbum): Promise<Album>
-  public updateOrCreate(data: SdkCreateAlbum[]): Promise<Album[]>
+  public updateOrCreate(
+    data: SdkCreateAlbum[],
+    manager?: EntityManager
+  ): Promise<Album[]>
 
-  async updateOrCreate(data: SdkCreateAlbum | SdkCreateAlbum[]) {
-    if (Array.isArray(data)) return this.updateOrCreateMany(data)
+  async updateOrCreate(
+    data: SdkCreateAlbum | SdkCreateAlbum[],
+    manager?: EntityManager
+  ) {
+    if (Array.isArray(data)) {
+      if (manager) return this.updateOrCreateManyInTransaction(data, manager)
+
+      return this.updateOrCreateMany(data)
+    }
 
     return this.updateOrCreateOne(data)
   }
@@ -99,5 +112,81 @@ export class AlbumsService {
     return Promise.all(
       fetchedAlbums.map(album => this.updateOrCreateOne(album))
     )
+  }
+
+  private async updateOrCreateManyInTransaction(
+    sdkAlbums: SdkCreateAlbum[],
+    manager: EntityManager
+  ) {
+    const albumsExternalIds = removeDuplicates(sdkAlbums.map(({ id }) => id))
+
+    const foundAlbums = await manager.findBy(Album, {
+      externalId: In(albumsExternalIds),
+    })
+    const albumsToCreate = sdkAlbums.filter(
+      ({ id }) => !foundAlbums.some(({ externalId }) => id === externalId)
+    )
+
+    const createdAlbums: Album[] = []
+
+    if (albumsToCreate.length === 0) return foundAlbums
+
+    for (const {
+      id,
+      name,
+      external_urls: { spotify: href },
+      genres,
+      album_type: albumType,
+      release_date,
+      release_date_precision,
+      copyrights,
+      total_tracks: totalTracks,
+      label,
+      images,
+      artists: sdkAlbumArtists,
+      tracks: { items: sdkAlbumTracks },
+    } of albumsToCreate) {
+      const createdArtists = await this.artistsService.updateOrCreate(
+        sdkAlbumArtists,
+        manager
+      )
+      const createdImages = await this.imagesService.findOrCreate(
+        images,
+        manager
+      )
+
+      const albumToCreate: Omit<CreateAlbum, 'images' | 'artists' | 'tracks'> =
+        {
+          name,
+          externalId: id,
+          href,
+          albumType,
+          releaseDate: new Date(release_date),
+          releaseDatePrecision: release_date_precision as ReleaseDatePrecision,
+          label,
+          copyrights: copyrights.map(({ text }) => text),
+          genres,
+          totalTracks,
+        }
+
+      const albumEntity = manager.create(Album, {
+        ...albumToCreate,
+        images: createdImages,
+        artists: createdArtists,
+      })
+
+      const createdAlbum = await manager.save(albumEntity)
+      const tracks = await this.tracksService.updateOrCreate(
+        sdkAlbumTracks,
+        manager,
+        createdAlbum
+      )
+
+      createdAlbum.tracks = tracks
+
+      createdAlbums.push(await manager.save(createdAlbum))
+    }
+
+    return [...foundAlbums, ...createdAlbums]
   }
 }

--- a/src/modules/items/albums/albums.service.ts
+++ b/src/modules/items/albums/albums.service.ts
@@ -18,7 +18,7 @@ export class AlbumsService {
     private readonly imagesService: ImagesService
   ) {}
 
-  async updateOrCreate(sdkAlbums: SdkCreateAlbum[], manager: EntityManager) {
+  async findOrCreate(sdkAlbums: SdkCreateAlbum[], manager: EntityManager) {
     const albumsExternalIds = removeDuplicates(sdkAlbums.map(({ id }) => id))
 
     const foundAlbums = await manager.findBy(Album, {
@@ -47,7 +47,7 @@ export class AlbumsService {
       artists: sdkAlbumArtists,
       tracks: { items: sdkAlbumTracks },
     } of albumsToCreate) {
-      const createdArtists = await this.artistsService.updateOrCreate(
+      const createdArtists = await this.artistsService.findOrCreate(
         sdkAlbumArtists,
         manager
       )
@@ -77,7 +77,7 @@ export class AlbumsService {
       })
 
       const createdAlbum = await manager.save(albumEntity)
-      const tracks = await this.tracksService.updateOrCreate(
+      const tracks = await this.tracksService.findOrCreate(
         sdkAlbumTracks,
         manager,
         createdAlbum

--- a/src/modules/items/artists/artists.module.ts
+++ b/src/modules/items/artists/artists.module.ts
@@ -1,12 +1,11 @@
 import { TypeOrmModule } from '@nestjs/typeorm'
 import { Module } from '@nestjs/common'
 
-import { ImagesModule } from '../images'
-
 import { Artist } from './artist.entity'
 import { ArtistsRepository } from './artists.repository'
 import { ArtistsService } from './artists.service'
 
+import { ImagesModule } from '@modules/items/images'
 import { SpotifyModule } from '@modules/spotify'
 
 @Module({

--- a/src/modules/items/artists/artists.module.ts
+++ b/src/modules/items/artists/artists.module.ts
@@ -1,6 +1,8 @@
 import { TypeOrmModule } from '@nestjs/typeorm'
 import { Module } from '@nestjs/common'
 
+import { ImagesModule } from '../images'
+
 import { Artist } from './artist.entity'
 import { ArtistsRepository } from './artists.repository'
 import { ArtistsService } from './artists.service'
@@ -8,7 +10,7 @@ import { ArtistsService } from './artists.service'
 import { SpotifyModule } from '@modules/spotify'
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Artist]), SpotifyModule],
+  imports: [TypeOrmModule.forFeature([Artist]), SpotifyModule, ImagesModule],
   providers: [ArtistsRepository, ArtistsService],
   exports: [ArtistsRepository, ArtistsService],
 })

--- a/src/modules/items/artists/artists.service.spec.ts
+++ b/src/modules/items/artists/artists.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { DataSource, EntityManager, In, UpdateResult } from 'typeorm'
-import { mock } from 'vitest-mock-extended'
+import { mock, MockProxy } from 'vitest-mock-extended'
 import { MockInstance } from 'vitest'
 
 import { ArtistsService } from './artists.service'
@@ -12,14 +12,17 @@ import {
   sdkArtistMock,
   transactionFactoryMock,
   entityManagerFactoryMock,
+  sdkImagesMock,
 } from '@common/mocks'
-import { Image } from '@modules/items/images'
+import { Image, ImagesService } from '@modules/items/images'
 import { EntityManagerCreateMockInstance } from '@common/types/mocks'
+import { SdkArtist } from '@common/types/spotify'
 
 describe('ArtistsService', () => {
   let moduleRef: TestingModule
   let entityManagerMock: EntityManager
   let artistsService: ArtistsService
+  let imagesService: ImagesService
 
   beforeEach(async () => {
     entityManagerMock = entityManagerFactoryMock()
@@ -33,10 +36,17 @@ describe('ArtistsService', () => {
             transaction: transactionFactoryMock(entityManagerMock),
           },
         },
+        {
+          provide: ImagesService,
+          useValue: {
+            findOrCreate: vi.fn(),
+          },
+        },
       ],
     }).compile()
 
     artistsService = moduleRef.get(ArtistsService)
+    imagesService = moduleRef.get(ImagesService)
   })
 
   afterEach(() => {
@@ -112,6 +122,106 @@ describe('ArtistsService', () => {
           Array.from({ length: 5 }).map(() => artistEntityMock)
         )
         expect(updateOrCreateOneSpy).toHaveBeenCalledTimes(5)
+      })
+    })
+
+    describe('updateOrCreateManyInTransaction', () => {
+      const artistsExternalIds = ['id1', 'id2', 'id3']
+
+      let sdkArtistsMock: MockProxy<SdkArtist>[]
+      let artistsMock: MockProxy<Artist>[]
+
+      let findBySpy: MockInstance
+      let createSpy: MockInstance
+      let saveSpy: MockInstance
+      let imagesFindOrCreateSpy: MockInstance
+
+      beforeEach(() => {
+        sdkArtistsMock = Array.from({ length: 3 }, (_, index) =>
+          mock<SdkArtist>({
+            id: artistsExternalIds[index],
+            images: sdkImagesMock,
+            type: 'artist',
+          })
+        )
+        artistsMock = Array.from({ length: 3 }, (_, index) =>
+          mock<Artist>({
+            externalId: artistsExternalIds[index],
+            images: imagesMock,
+          })
+        )
+
+        findBySpy = vi.spyOn(entityManagerMock, 'findBy')
+        createSpy = vi.spyOn(entityManagerMock, 'create')
+        saveSpy = vi.spyOn(entityManagerMock, 'save')
+        imagesFindOrCreateSpy = vi.spyOn(imagesService, 'findOrCreate')
+      })
+
+      test('should find all artists and does not create any', async () => {
+        findBySpy.mockResolvedValue(artistsMock)
+
+        expect(
+          await artistsService.updateOrCreate(sdkArtistsMock, entityManagerMock)
+        ).toEqual(artistsMock)
+
+        expect(findBySpy).toHaveBeenCalledWith(Artist, {
+          externalId: In(artistsExternalIds),
+        })
+        expect(findBySpy).toHaveBeenCalledTimes(1)
+        expect(createSpy).not.toHaveBeenCalled()
+        expect(saveSpy).not.toHaveBeenCalled()
+        expect(imagesFindOrCreateSpy).not.toHaveBeenCalled()
+      })
+
+      test('should not find any artists and create all', async () => {
+        findBySpy.mockResolvedValueOnce([])
+        createSpy.mockImplementation((_, { externalId }) =>
+          artistsMock.find(artist => artist.externalId === externalId)
+        )
+        saveSpy.mockResolvedValue(artistsMock)
+        imagesFindOrCreateSpy.mockResolvedValue(imagesMock)
+
+        expect(
+          await artistsService.updateOrCreate(sdkArtistsMock, entityManagerMock)
+        ).toEqual(artistsMock)
+
+        expect(findBySpy).toHaveBeenCalledWith(Artist, {
+          externalId: In(artistsExternalIds),
+        })
+        expect(createSpy).toHaveBeenCalledWith(Artist, expect.anything())
+        expect(createSpy).toHaveBeenCalledTimes(3)
+        expect(saveSpy).toHaveBeenCalledWith(artistsMock)
+        expect(imagesFindOrCreateSpy).toHaveBeenCalledWith(
+          sdkImagesMock,
+          entityManagerMock
+        )
+        expect(imagesFindOrCreateSpy).toHaveBeenCalledTimes(3)
+      })
+
+      test('should find some artists and create the rest', async () => {
+        const foundArtistsMock = [artistsMock[0], artistsMock[1]]
+
+        findBySpy.mockResolvedValueOnce(foundArtistsMock)
+        createSpy.mockImplementation((_, { externalId }) =>
+          artistsMock.find(artist => artist.externalId === externalId)
+        )
+        saveSpy.mockResolvedValue([artistsMock[2]])
+
+        expect(
+          await artistsService.updateOrCreate(sdkArtistsMock, entityManagerMock)
+        ).toEqual(artistsMock)
+
+        expect(findBySpy).toHaveBeenCalledWith(Artist, {
+          externalId: In(artistsExternalIds),
+        })
+        expect(createSpy).toHaveBeenCalledWith(Artist, expect.anything())
+        expect(createSpy).toHaveBeenCalledTimes(1)
+        expect(saveSpy).toHaveBeenCalledWith([artistsMock[2]])
+        expect(imagesFindOrCreateSpy).toHaveBeenCalledWith(
+          sdkImagesMock,
+          entityManagerMock
+        )
+        expect(imagesFindOrCreateSpy).toHaveBeenCalledTimes(1)
       })
     })
   })

--- a/src/modules/items/artists/artists.service.spec.ts
+++ b/src/modules/items/artists/artists.service.spec.ts
@@ -47,7 +47,7 @@ describe('ArtistsService', () => {
     expect(artistsService).toBeDefined()
   })
 
-  describe('updateOrCreate', () => {
+  describe('findOrCreate', () => {
     const artistsExternalIds = ['id1', 'id2', 'id3']
 
     let sdkArtistsMock: MockProxy<SdkArtist>[]
@@ -83,7 +83,7 @@ describe('ArtistsService', () => {
       findBySpy.mockResolvedValue(artistsMock)
 
       expect(
-        await artistsService.updateOrCreate(sdkArtistsMock, entityManagerMock)
+        await artistsService.findOrCreate(sdkArtistsMock, entityManagerMock)
       ).toEqual(artistsMock)
 
       expect(findBySpy).toHaveBeenCalledWith(Artist, {
@@ -104,7 +104,7 @@ describe('ArtistsService', () => {
       imagesFindOrCreateSpy.mockResolvedValue(imagesMock)
 
       expect(
-        await artistsService.updateOrCreate(sdkArtistsMock, entityManagerMock)
+        await artistsService.findOrCreate(sdkArtistsMock, entityManagerMock)
       ).toEqual(artistsMock)
 
       expect(findBySpy).toHaveBeenCalledWith(Artist, {
@@ -130,7 +130,7 @@ describe('ArtistsService', () => {
       saveSpy.mockResolvedValue([artistsMock[2]])
 
       expect(
-        await artistsService.updateOrCreate(sdkArtistsMock, entityManagerMock)
+        await artistsService.findOrCreate(sdkArtistsMock, entityManagerMock)
       ).toEqual(artistsMock)
 
       expect(findBySpy).toHaveBeenCalledWith(Artist, {

--- a/src/modules/items/artists/artists.service.spec.ts
+++ b/src/modules/items/artists/artists.service.spec.ts
@@ -1,22 +1,18 @@
 import { Test, TestingModule } from '@nestjs/testing'
-import { DataSource, EntityManager, In, UpdateResult } from 'typeorm'
-import { mock, MockProxy } from 'vitest-mock-extended'
+import { EntityManager, In } from 'typeorm'
 import { MockInstance } from 'vitest'
+import { mock, MockProxy } from 'vitest-mock-extended'
 
-import { ArtistsService } from './artists.service'
 import { Artist } from './artist.entity'
+import { ArtistsService } from './artists.service'
 
 import {
-  artistEntityMock,
-  imagesMock,
-  sdkArtistMock,
-  transactionFactoryMock,
   entityManagerFactoryMock,
+  imagesMock,
   sdkImagesMock,
 } from '@common/mocks'
-import { Image, ImagesService } from '@modules/items/images'
-import { EntityManagerCreateMockInstance } from '@common/types/mocks'
 import { SdkArtist } from '@common/types/spotify'
+import { ImagesService } from '@modules/items/images'
 
 describe('ArtistsService', () => {
   let moduleRef: TestingModule
@@ -30,12 +26,6 @@ describe('ArtistsService', () => {
     moduleRef = await Test.createTestingModule({
       providers: [
         ArtistsService,
-        {
-          provide: DataSource,
-          useValue: {
-            transaction: transactionFactoryMock(entityManagerMock),
-          },
-        },
         {
           provide: ImagesService,
           useValue: {
@@ -58,171 +48,102 @@ describe('ArtistsService', () => {
   })
 
   describe('updateOrCreate', () => {
-    describe('updateOrCreateOne', () => {
-      let findOneBySpy: MockInstance
+    const artistsExternalIds = ['id1', 'id2', 'id3']
 
-      beforeEach(() => {
-        findOneBySpy = vi.spyOn(entityManagerMock, 'findOneBy')
-      })
+    let sdkArtistsMock: MockProxy<SdkArtist>[]
+    let artistsMock: MockProxy<Artist>[]
 
-      test('should update artist if found', async () => {
-        findOneBySpy.mockResolvedValue(artistEntityMock)
-        const updateSpy = vi
-          .spyOn(entityManagerMock, 'update')
-          .mockResolvedValue(mock<UpdateResult>())
+    let findBySpy: MockInstance
+    let createSpy: MockInstance
+    let saveSpy: MockInstance
+    let imagesFindOrCreateSpy: MockInstance
 
-        expect(await artistsService.updateOrCreate(sdkArtistMock)).toEqual(
-          artistEntityMock
-        )
-        expect(findOneBySpy).toHaveBeenCalledWith(Artist, {
-          externalId: sdkArtistMock.id,
+    beforeEach(() => {
+      sdkArtistsMock = Array.from({ length: 3 }, (_, index) =>
+        mock<SdkArtist>({
+          id: artistsExternalIds[index],
+          images: sdkImagesMock,
+          type: 'artist',
         })
-        expect(findOneBySpy).toHaveBeenCalledTimes(2)
-        expect(updateSpy).toHaveBeenCalled()
-      })
-
-      test('should create artist if not found', async () => {
-        findOneBySpy.mockResolvedValue(null)
-        const findBy = vi
-          .spyOn(entityManagerMock, 'findBy')
-          .mockResolvedValue(imagesMock)
-        const createSpy = (
-          vi.spyOn(
-            entityManagerMock,
-            'create'
-          ) as EntityManagerCreateMockInstance
-        ).mockReturnValue(artistEntityMock)
-        const saveSpy = vi
-          .spyOn(entityManagerMock, 'save')
-          .mockResolvedValue(artistEntityMock)
-
-        expect(await artistsService.updateOrCreate(sdkArtistMock)).toEqual(
-          artistEntityMock
-        )
-        expect(findOneBySpy).toHaveBeenCalledWith(Artist, {
-          externalId: sdkArtistMock.id,
+      )
+      artistsMock = Array.from({ length: 3 }, (_, index) =>
+        mock<Artist>({
+          externalId: artistsExternalIds[index],
+          images: imagesMock,
         })
-        expect(findOneBySpy).toHaveBeenCalledTimes(1)
-        expect(findBy).toHaveBeenCalledWith(Image, {
-          url: In(imagesMock.map(image => image.url)),
-        })
-        expect(createSpy).toHaveBeenCalled()
-        expect(saveSpy).toHaveBeenCalledWith(artistEntityMock)
-      })
+      )
+
+      findBySpy = vi.spyOn(entityManagerMock, 'findBy')
+      createSpy = vi.spyOn(entityManagerMock, 'create')
+      saveSpy = vi.spyOn(entityManagerMock, 'save')
+      imagesFindOrCreateSpy = vi.spyOn(imagesService, 'findOrCreate')
     })
 
-    describe('updateOrCreateMany', () => {
-      test('should update or create many artists', async () => {
-        const updateOrCreateOneSpy = vi
-          // `as never` is used to avoid type error with private methods
-          .spyOn(artistsService as never, 'updateOrCreateOne')
-          .mockResolvedValue(artistEntityMock)
-        const artists = Array.from({ length: 5 }).map(() => sdkArtistMock)
-        expect(await artistsService.updateOrCreate(artists)).toEqual(
-          Array.from({ length: 5 }).map(() => artistEntityMock)
-        )
-        expect(updateOrCreateOneSpy).toHaveBeenCalledTimes(5)
+    test('should find all artists and does not create any', async () => {
+      findBySpy.mockResolvedValue(artistsMock)
+
+      expect(
+        await artistsService.updateOrCreate(sdkArtistsMock, entityManagerMock)
+      ).toEqual(artistsMock)
+
+      expect(findBySpy).toHaveBeenCalledWith(Artist, {
+        externalId: In(artistsExternalIds),
       })
+      expect(findBySpy).toHaveBeenCalledTimes(1)
+      expect(createSpy).not.toHaveBeenCalled()
+      expect(saveSpy).not.toHaveBeenCalled()
+      expect(imagesFindOrCreateSpy).not.toHaveBeenCalled()
     })
 
-    describe('updateOrCreateManyInTransaction', () => {
-      const artistsExternalIds = ['id1', 'id2', 'id3']
+    test('should not find any artists and create all', async () => {
+      findBySpy.mockResolvedValueOnce([])
+      createSpy.mockImplementation((_, { externalId }) =>
+        artistsMock.find(artist => artist.externalId === externalId)
+      )
+      saveSpy.mockResolvedValue(artistsMock)
+      imagesFindOrCreateSpy.mockResolvedValue(imagesMock)
 
-      let sdkArtistsMock: MockProxy<SdkArtist>[]
-      let artistsMock: MockProxy<Artist>[]
+      expect(
+        await artistsService.updateOrCreate(sdkArtistsMock, entityManagerMock)
+      ).toEqual(artistsMock)
 
-      let findBySpy: MockInstance
-      let createSpy: MockInstance
-      let saveSpy: MockInstance
-      let imagesFindOrCreateSpy: MockInstance
-
-      beforeEach(() => {
-        sdkArtistsMock = Array.from({ length: 3 }, (_, index) =>
-          mock<SdkArtist>({
-            id: artistsExternalIds[index],
-            images: sdkImagesMock,
-            type: 'artist',
-          })
-        )
-        artistsMock = Array.from({ length: 3 }, (_, index) =>
-          mock<Artist>({
-            externalId: artistsExternalIds[index],
-            images: imagesMock,
-          })
-        )
-
-        findBySpy = vi.spyOn(entityManagerMock, 'findBy')
-        createSpy = vi.spyOn(entityManagerMock, 'create')
-        saveSpy = vi.spyOn(entityManagerMock, 'save')
-        imagesFindOrCreateSpy = vi.spyOn(imagesService, 'findOrCreate')
+      expect(findBySpy).toHaveBeenCalledWith(Artist, {
+        externalId: In(artistsExternalIds),
       })
+      expect(createSpy).toHaveBeenCalledWith(Artist, expect.anything())
+      expect(createSpy).toHaveBeenCalledTimes(3)
+      expect(saveSpy).toHaveBeenCalledWith(artistsMock)
+      expect(imagesFindOrCreateSpy).toHaveBeenCalledWith(
+        sdkImagesMock,
+        entityManagerMock
+      )
+      expect(imagesFindOrCreateSpy).toHaveBeenCalledTimes(3)
+    })
 
-      test('should find all artists and does not create any', async () => {
-        findBySpy.mockResolvedValue(artistsMock)
+    test('should find some artists and create the rest', async () => {
+      const foundArtistsMock = [artistsMock[0], artistsMock[1]]
 
-        expect(
-          await artistsService.updateOrCreate(sdkArtistsMock, entityManagerMock)
-        ).toEqual(artistsMock)
+      findBySpy.mockResolvedValueOnce(foundArtistsMock)
+      createSpy.mockImplementation((_, { externalId }) =>
+        artistsMock.find(artist => artist.externalId === externalId)
+      )
+      saveSpy.mockResolvedValue([artistsMock[2]])
 
-        expect(findBySpy).toHaveBeenCalledWith(Artist, {
-          externalId: In(artistsExternalIds),
-        })
-        expect(findBySpy).toHaveBeenCalledTimes(1)
-        expect(createSpy).not.toHaveBeenCalled()
-        expect(saveSpy).not.toHaveBeenCalled()
-        expect(imagesFindOrCreateSpy).not.toHaveBeenCalled()
+      expect(
+        await artistsService.updateOrCreate(sdkArtistsMock, entityManagerMock)
+      ).toEqual(artistsMock)
+
+      expect(findBySpy).toHaveBeenCalledWith(Artist, {
+        externalId: In(artistsExternalIds),
       })
-
-      test('should not find any artists and create all', async () => {
-        findBySpy.mockResolvedValueOnce([])
-        createSpy.mockImplementation((_, { externalId }) =>
-          artistsMock.find(artist => artist.externalId === externalId)
-        )
-        saveSpy.mockResolvedValue(artistsMock)
-        imagesFindOrCreateSpy.mockResolvedValue(imagesMock)
-
-        expect(
-          await artistsService.updateOrCreate(sdkArtistsMock, entityManagerMock)
-        ).toEqual(artistsMock)
-
-        expect(findBySpy).toHaveBeenCalledWith(Artist, {
-          externalId: In(artistsExternalIds),
-        })
-        expect(createSpy).toHaveBeenCalledWith(Artist, expect.anything())
-        expect(createSpy).toHaveBeenCalledTimes(3)
-        expect(saveSpy).toHaveBeenCalledWith(artistsMock)
-        expect(imagesFindOrCreateSpy).toHaveBeenCalledWith(
-          sdkImagesMock,
-          entityManagerMock
-        )
-        expect(imagesFindOrCreateSpy).toHaveBeenCalledTimes(3)
-      })
-
-      test('should find some artists and create the rest', async () => {
-        const foundArtistsMock = [artistsMock[0], artistsMock[1]]
-
-        findBySpy.mockResolvedValueOnce(foundArtistsMock)
-        createSpy.mockImplementation((_, { externalId }) =>
-          artistsMock.find(artist => artist.externalId === externalId)
-        )
-        saveSpy.mockResolvedValue([artistsMock[2]])
-
-        expect(
-          await artistsService.updateOrCreate(sdkArtistsMock, entityManagerMock)
-        ).toEqual(artistsMock)
-
-        expect(findBySpy).toHaveBeenCalledWith(Artist, {
-          externalId: In(artistsExternalIds),
-        })
-        expect(createSpy).toHaveBeenCalledWith(Artist, expect.anything())
-        expect(createSpy).toHaveBeenCalledTimes(1)
-        expect(saveSpy).toHaveBeenCalledWith([artistsMock[2]])
-        expect(imagesFindOrCreateSpy).toHaveBeenCalledWith(
-          sdkImagesMock,
-          entityManagerMock
-        )
-        expect(imagesFindOrCreateSpy).toHaveBeenCalledTimes(1)
-      })
+      expect(createSpy).toHaveBeenCalledWith(Artist, expect.anything())
+      expect(createSpy).toHaveBeenCalledTimes(1)
+      expect(saveSpy).toHaveBeenCalledWith([artistsMock[2]])
+      expect(imagesFindOrCreateSpy).toHaveBeenCalledWith(
+        sdkImagesMock,
+        entityManagerMock
+      )
+      expect(imagesFindOrCreateSpy).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/modules/items/artists/artists.service.ts
+++ b/src/modules/items/artists/artists.service.ts
@@ -1,20 +1,34 @@
 import { Injectable } from '@nestjs/common'
-import { DataSource, In } from 'typeorm'
+import { DataSource, EntityManager, In } from 'typeorm'
 
-import { CreateArtist, SdkCreateArtist } from './dtos'
 import { Artist } from './artist.entity'
+import { CreateArtist, SdkCreateArtist } from './dtos'
 
-import { Image } from '@modules/items/images'
+import { removeDuplicates } from '@common/utils'
+import { Image, ImagesService } from '@modules/items/images'
 
 @Injectable()
 export class ArtistsService {
-  constructor(private readonly dataSource: DataSource) {}
+  constructor(
+    private readonly dataSource: DataSource,
+    private readonly imagesService: ImagesService
+  ) {}
 
   public updateOrCreate(data: SdkCreateArtist): Promise<Artist>
-  public updateOrCreate(data: SdkCreateArtist[]): Promise<Artist[]>
+  public updateOrCreate(
+    data: SdkCreateArtist[],
+    manager?: EntityManager
+  ): Promise<Artist[]>
 
-  async updateOrCreate(data: SdkCreateArtist | SdkCreateArtist[]) {
-    if (Array.isArray(data)) return this.updateOrCreateMany(data)
+  async updateOrCreate(
+    data: SdkCreateArtist | SdkCreateArtist[],
+    manager?: EntityManager
+  ) {
+    if (Array.isArray(data)) {
+      if (manager) return this.updateOrCreateManyInTransaction(data, manager)
+
+      return this.updateOrCreateMany(data)
+    }
 
     return this.updateOrCreateOne(data)
   }
@@ -67,5 +81,58 @@ export class ArtistsService {
 
   private async updateOrCreateMany(artists: SdkCreateArtist[]) {
     return Promise.all(artists.map(artist => this.updateOrCreateOne(artist)))
+  }
+
+  private async updateOrCreateManyInTransaction(
+    sdkArtists: SdkCreateArtist[],
+    manager: EntityManager
+  ) {
+    const artistsExternalIds = removeDuplicates(sdkArtists.map(({ id }) => id))
+
+    const foundArtists = await manager.findBy(Artist, {
+      externalId: In(artistsExternalIds),
+    })
+    const artistsToCreate = sdkArtists.filter(
+      ({ id }) => !foundArtists.some(({ externalId }) => id === externalId)
+    )
+
+    const artistsEntities: Artist[] = []
+
+    if (artistsToCreate.length === 0) return foundArtists
+
+    for (const {
+      id,
+      name,
+      external_urls: { spotify: href },
+      genres,
+      popularity,
+      followers,
+      images,
+    } of artistsToCreate) {
+      const createdImages = await this.imagesService.findOrCreate(
+        images,
+        manager
+      )
+
+      const artistToCreate: Omit<CreateArtist, 'images'> = {
+        externalId: id,
+        name,
+        href,
+        genres,
+        popularity,
+        followers: followers.total,
+      }
+
+      const artistEntity = manager.create(Artist, {
+        ...artistToCreate,
+        images: createdImages,
+      })
+
+      artistsEntities.push(artistEntity)
+    }
+
+    const createdArtists = await manager.save(artistsEntities)
+
+    return [...foundArtists, ...createdArtists]
   }
 }

--- a/src/modules/items/artists/artists.service.ts
+++ b/src/modules/items/artists/artists.service.ts
@@ -1,92 +1,17 @@
 import { Injectable } from '@nestjs/common'
-import { DataSource, EntityManager, In } from 'typeorm'
+import { EntityManager, In } from 'typeorm'
 
 import { Artist } from './artist.entity'
 import { CreateArtist, SdkCreateArtist } from './dtos'
 
 import { removeDuplicates } from '@common/utils'
-import { Image, ImagesService } from '@modules/items/images'
+import { ImagesService } from '@modules/items/images'
 
 @Injectable()
 export class ArtistsService {
-  constructor(
-    private readonly dataSource: DataSource,
-    private readonly imagesService: ImagesService
-  ) {}
+  constructor(private readonly imagesService: ImagesService) {}
 
-  public updateOrCreate(data: SdkCreateArtist): Promise<Artist>
-  public updateOrCreate(
-    data: SdkCreateArtist[],
-    manager?: EntityManager
-  ): Promise<Artist[]>
-
-  async updateOrCreate(
-    data: SdkCreateArtist | SdkCreateArtist[],
-    manager?: EntityManager
-  ) {
-    if (Array.isArray(data)) {
-      if (manager) return this.updateOrCreateManyInTransaction(data, manager)
-
-      return this.updateOrCreateMany(data)
-    }
-
-    return this.updateOrCreateOne(data)
-  }
-
-  private async updateOrCreateOne({
-    id,
-    name,
-    external_urls: { spotify: href },
-    genres,
-    popularity,
-    followers: { total: followers },
-    images: fetchedArtistImages,
-  }: SdkCreateArtist) {
-    return this.dataSource.transaction(async manager => {
-      const foundArtist = await manager.findOneBy(Artist, {
-        externalId: id,
-      })
-
-      const artistToCreate: Omit<CreateArtist, 'images'> = {
-        externalId: id,
-        name,
-        href,
-        genres,
-        popularity,
-        followers,
-      }
-
-      if (foundArtist) {
-        await manager.update(Artist, { externalId: id }, artistToCreate)
-
-        const foundCreatedArtist = await manager.findOneBy(Artist, {
-          externalId: id,
-        })
-
-        return foundCreatedArtist!
-      }
-
-      const images = await manager.findBy(Image, {
-        url: In(fetchedArtistImages.map(image => image.url)),
-      })
-
-      const artistEntity = manager.create(Artist, {
-        ...artistToCreate,
-        images,
-      })
-
-      return manager.save(artistEntity)
-    })
-  }
-
-  private async updateOrCreateMany(artists: SdkCreateArtist[]) {
-    return Promise.all(artists.map(artist => this.updateOrCreateOne(artist)))
-  }
-
-  private async updateOrCreateManyInTransaction(
-    sdkArtists: SdkCreateArtist[],
-    manager: EntityManager
-  ) {
+  async updateOrCreate(sdkArtists: SdkCreateArtist[], manager: EntityManager) {
     const artistsExternalIds = removeDuplicates(sdkArtists.map(({ id }) => id))
 
     const foundArtists = await manager.findBy(Artist, {

--- a/src/modules/items/artists/artists.service.ts
+++ b/src/modules/items/artists/artists.service.ts
@@ -11,7 +11,7 @@ import { ImagesService } from '@modules/items/images'
 export class ArtistsService {
   constructor(private readonly imagesService: ImagesService) {}
 
-  async updateOrCreate(sdkArtists: SdkCreateArtist[], manager: EntityManager) {
+  async findOrCreate(sdkArtists: SdkCreateArtist[], manager: EntityManager) {
     const artistsExternalIds = removeDuplicates(sdkArtists.map(({ id }) => id))
 
     const foundArtists = await manager.findBy(Artist, {

--- a/src/modules/items/images/images.service.spec.ts
+++ b/src/modules/items/images/images.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing'
-import { DataSource, EntityManager } from 'typeorm'
+import { DataSource, EntityManager, In } from 'typeorm'
 import { MockInstance } from 'vitest'
+import { mock, MockProxy } from 'vitest-mock-extended'
 
 import { ImagesService } from './images.service'
 import { ImagesRepository } from './images.repository'
@@ -15,6 +16,7 @@ import {
   transactionFactoryMock,
 } from '@common/mocks'
 import { EntityManagerCreateMockInstance } from '@common/types/mocks'
+import { SdkImage } from '@common/types/spotify'
 
 describe('ImagesService', () => {
   let moduleRef: TestingModule
@@ -122,6 +124,91 @@ describe('ImagesService', () => {
         )
         expect(findOrCreateOneSpy).toHaveBeenCalledWith(sdkImageMock)
         expect(findOrCreateOneSpy).toHaveBeenCalledTimes(sdkImagesMock.length)
+      })
+    })
+
+    describe('findOrCreateManyInTransaction', () => {
+      const imagesUrls = ['url1', 'url2', 'url3']
+
+      let sdkImagesMock: MockProxy<SdkImage[]>
+      let imagesMock: MockProxy<Image[]>
+
+      let findBySpy: MockInstance
+      let createSpy: MockInstance
+      let saveSpy: MockInstance
+
+      beforeEach(() => {
+        sdkImagesMock = Array.from({ length: 3 }, (_, index) =>
+          mock<SdkImage>({
+            url: imagesUrls[index],
+          })
+        )
+        imagesMock = Array.from({ length: 3 }, (_, index) =>
+          mock<Image>({
+            url: imagesUrls[index],
+          })
+        )
+
+        findBySpy = vi.spyOn(entityManagerMock, 'findBy')
+        createSpy = vi.spyOn(entityManagerMock, 'create')
+        saveSpy = vi.spyOn(entityManagerMock, 'save')
+      })
+
+      test('should return empty array if no images', async () => {
+        expect(await imagesService.findOrCreate([], entityManagerMock)).toEqual(
+          []
+        )
+
+        expect(findBySpy).not.toHaveBeenCalled()
+        expect(createSpy).not.toHaveBeenCalled()
+        expect(saveSpy).not.toHaveBeenCalled()
+      })
+
+      test('should find all images and does not create any', async () => {
+        findBySpy.mockResolvedValue(imagesMock)
+
+        expect(
+          await imagesService.findOrCreate(sdkImagesMock, entityManagerMock)
+        ).toEqual(imagesMock)
+
+        expect(findBySpy).toHaveBeenCalledWith(Image, {
+          url: In(imagesMock.map(image => image.url)),
+        })
+        expect(findBySpy).toHaveBeenCalledTimes(1)
+        expect(createSpy).not.toHaveBeenCalled()
+        expect(saveSpy).not.toHaveBeenCalled()
+      })
+
+      test('should not find any images and create all', async () => {
+        findBySpy.mockResolvedValue([])
+        createSpy.mockReturnValue(imagesMock)
+        saveSpy.mockResolvedValue(imagesMock)
+
+        expect(
+          await imagesService.findOrCreate(sdkImagesMock, entityManagerMock)
+        ).toEqual(imagesMock)
+
+        expect(findBySpy).toHaveBeenCalledWith(Image, {
+          url: In(imagesMock.map(image => image.url)),
+        })
+        expect(createSpy).toHaveBeenCalledWith(Image, sdkImagesMock)
+        expect(saveSpy).toHaveBeenCalledWith(imagesMock)
+      })
+
+      test('should find some images and create the rest', async () => {
+        findBySpy.mockResolvedValue([imagesMock[0], imagesMock[1]])
+        createSpy.mockReturnValue([imagesMock[2]])
+        saveSpy.mockResolvedValue([imagesMock[2]])
+
+        expect(
+          await imagesService.findOrCreate(sdkImagesMock, entityManagerMock)
+        ).toEqual(imagesMock)
+
+        expect(findBySpy).toHaveBeenCalledWith(Image, {
+          url: In(imagesMock.map(image => image.url)),
+        })
+        expect(createSpy).toHaveBeenCalledWith(Image, [sdkImagesMock[2]])
+        expect(saveSpy).toHaveBeenCalledWith([imagesMock[2]])
       })
     })
   })

--- a/src/modules/items/images/images.service.spec.ts
+++ b/src/modules/items/images/images.service.spec.ts
@@ -1,53 +1,27 @@
 import { Test, TestingModule } from '@nestjs/testing'
-import { DataSource, EntityManager, In } from 'typeorm'
+import { EntityManager, In } from 'typeorm'
 import { MockInstance } from 'vitest'
 import { mock, MockProxy } from 'vitest-mock-extended'
 
-import { ImagesService } from './images.service'
-import { ImagesRepository } from './images.repository'
 import { Image } from './image.entity'
+import { ImagesService } from './images.service'
 
-import {
-  entityManagerFactoryMock,
-  imageMock,
-  imagesMock,
-  sdkImageMock,
-  sdkImagesMock,
-  transactionFactoryMock,
-} from '@common/mocks'
-import { EntityManagerCreateMockInstance } from '@common/types/mocks'
+import { entityManagerFactoryMock } from '@common/mocks'
 import { SdkImage } from '@common/types/spotify'
 
 describe('ImagesService', () => {
   let moduleRef: TestingModule
-  let entityManagerMock: EntityManager
   let imagesService: ImagesService
-  let imagesRepository: ImagesRepository
+  let entityManagerMock: EntityManager
 
   beforeEach(async () => {
     entityManagerMock = entityManagerFactoryMock()
 
     moduleRef = await Test.createTestingModule({
-      providers: [
-        ImagesService,
-        {
-          provide: ImagesRepository,
-          useValue: {
-            findImageByUrl: vi.fn(),
-            createImage: vi.fn(),
-          },
-        },
-        {
-          provide: DataSource,
-          useValue: {
-            transaction: transactionFactoryMock(entityManagerMock),
-          },
-        },
-      ],
+      providers: [ImagesService],
     }).compile()
 
     imagesService = moduleRef.get(ImagesService)
-    imagesRepository = moduleRef.get(ImagesRepository)
   })
 
   afterEach(() => {
@@ -58,158 +32,88 @@ describe('ImagesService', () => {
     expect(imagesService).toBeDefined()
   })
 
-  test('create', async () => {
-    const createImageSpy = vi
-      .spyOn(imagesRepository, 'createImage')
-      .mockResolvedValue(imageMock)
-
-    expect(await imagesService.create(sdkImageMock)).toEqual(imageMock)
-    expect(createImageSpy).toHaveBeenCalledWith(sdkImageMock)
-  })
-
   describe('findOrCreate', () => {
-    describe('findOrCreateOne', () => {
-      let findOneBySpy: MockInstance
+    const imagesUrls = ['url1', 'url2', 'url3']
 
-      beforeEach(() => {
-        findOneBySpy = vi.spyOn(entityManagerMock, 'findOneBy')
-      })
+    let sdkImagesMock: MockProxy<SdkImage[]>
+    let imagesMock: MockProxy<Image[]>
 
-      test('should find image if exists', async () => {
-        findOneBySpy.mockResolvedValue(imageMock)
+    let findBySpy: MockInstance
+    let createSpy: MockInstance
+    let saveSpy: MockInstance
 
-        expect(await imagesService.findOrCreate(sdkImageMock)).toEqual(
-          imageMock
-        )
-        expect(findOneBySpy).toHaveBeenCalledWith(Image, {
-          url: sdkImageMock.url,
+    beforeEach(() => {
+      sdkImagesMock = Array.from({ length: 3 }, (_, index) =>
+        mock<SdkImage>({
+          url: imagesUrls[index],
         })
-      })
-
-      test('should create image if not found', async () => {
-        findOneBySpy.mockResolvedValue(null)
-        const createSpy = (
-          vi.spyOn(
-            entityManagerMock,
-            'create'
-          ) as EntityManagerCreateMockInstance
-        ).mockReturnValue(imageMock)
-        const saveSpy = vi
-          .spyOn(entityManagerMock, 'save')
-          .mockResolvedValue(imageMock)
-
-        expect(await imagesService.findOrCreate(sdkImageMock)).toEqual(
-          imageMock
-        )
-        expect(findOneBySpy).toHaveBeenCalledWith(Image, {
-          url: sdkImageMock.url,
+      )
+      imagesMock = Array.from({ length: 3 }, (_, index) =>
+        mock<Image>({
+          url: imagesUrls[index],
         })
-        expect(createSpy).toHaveBeenCalledWith(Image, sdkImageMock)
-        expect(saveSpy).toHaveBeenCalledWith(imageMock)
-      })
+      )
+
+      findBySpy = vi.spyOn(entityManagerMock, 'findBy')
+      createSpy = vi.spyOn(entityManagerMock, 'create')
+      saveSpy = vi.spyOn(entityManagerMock, 'save')
     })
 
-    describe('findOrCreateMany', () => {
-      test('should return empty array if no images', async () => {
-        expect(await imagesService.findOrCreate([])).toEqual([])
-      })
+    test('should return empty array if no images', async () => {
+      expect(await imagesService.findOrCreate([], entityManagerMock)).toEqual(
+        []
+      )
 
-      test('should find or create images', async () => {
-        const findOrCreateOneSpy = vi
-          .spyOn(imagesService as never, 'findOrCreateOne')
-          .mockResolvedValue(imageMock)
-
-        expect(await imagesService.findOrCreate(sdkImagesMock)).toEqual(
-          imagesMock
-        )
-        expect(findOrCreateOneSpy).toHaveBeenCalledWith(sdkImageMock)
-        expect(findOrCreateOneSpy).toHaveBeenCalledTimes(sdkImagesMock.length)
-      })
+      expect(findBySpy).not.toHaveBeenCalled()
+      expect(createSpy).not.toHaveBeenCalled()
+      expect(saveSpy).not.toHaveBeenCalled()
     })
 
-    describe('findOrCreateManyInTransaction', () => {
-      const imagesUrls = ['url1', 'url2', 'url3']
+    test('should find all images and does not create any', async () => {
+      findBySpy.mockResolvedValue(imagesMock)
 
-      let sdkImagesMock: MockProxy<SdkImage[]>
-      let imagesMock: MockProxy<Image[]>
+      expect(
+        await imagesService.findOrCreate(sdkImagesMock, entityManagerMock)
+      ).toEqual(imagesMock)
 
-      let findBySpy: MockInstance
-      let createSpy: MockInstance
-      let saveSpy: MockInstance
-
-      beforeEach(() => {
-        sdkImagesMock = Array.from({ length: 3 }, (_, index) =>
-          mock<SdkImage>({
-            url: imagesUrls[index],
-          })
-        )
-        imagesMock = Array.from({ length: 3 }, (_, index) =>
-          mock<Image>({
-            url: imagesUrls[index],
-          })
-        )
-
-        findBySpy = vi.spyOn(entityManagerMock, 'findBy')
-        createSpy = vi.spyOn(entityManagerMock, 'create')
-        saveSpy = vi.spyOn(entityManagerMock, 'save')
+      expect(findBySpy).toHaveBeenCalledWith(Image, {
+        url: In(imagesMock.map(image => image.url)),
       })
+      expect(findBySpy).toHaveBeenCalledTimes(1)
+      expect(createSpy).not.toHaveBeenCalled()
+      expect(saveSpy).not.toHaveBeenCalled()
+    })
 
-      test('should return empty array if no images', async () => {
-        expect(await imagesService.findOrCreate([], entityManagerMock)).toEqual(
-          []
-        )
+    test('should not find any images and create all', async () => {
+      findBySpy.mockResolvedValue([])
+      createSpy.mockReturnValue(imagesMock)
+      saveSpy.mockResolvedValue(imagesMock)
 
-        expect(findBySpy).not.toHaveBeenCalled()
-        expect(createSpy).not.toHaveBeenCalled()
-        expect(saveSpy).not.toHaveBeenCalled()
+      expect(
+        await imagesService.findOrCreate(sdkImagesMock, entityManagerMock)
+      ).toEqual(imagesMock)
+
+      expect(findBySpy).toHaveBeenCalledWith(Image, {
+        url: In(imagesMock.map(image => image.url)),
       })
+      expect(createSpy).toHaveBeenCalledWith(Image, sdkImagesMock)
+      expect(saveSpy).toHaveBeenCalledWith(imagesMock)
+    })
 
-      test('should find all images and does not create any', async () => {
-        findBySpy.mockResolvedValue(imagesMock)
+    test('should find some images and create the rest', async () => {
+      findBySpy.mockResolvedValue([imagesMock[0], imagesMock[1]])
+      createSpy.mockReturnValue([imagesMock[2]])
+      saveSpy.mockResolvedValue([imagesMock[2]])
 
-        expect(
-          await imagesService.findOrCreate(sdkImagesMock, entityManagerMock)
-        ).toEqual(imagesMock)
+      expect(
+        await imagesService.findOrCreate(sdkImagesMock, entityManagerMock)
+      ).toEqual(imagesMock)
 
-        expect(findBySpy).toHaveBeenCalledWith(Image, {
-          url: In(imagesMock.map(image => image.url)),
-        })
-        expect(findBySpy).toHaveBeenCalledTimes(1)
-        expect(createSpy).not.toHaveBeenCalled()
-        expect(saveSpy).not.toHaveBeenCalled()
+      expect(findBySpy).toHaveBeenCalledWith(Image, {
+        url: In(imagesMock.map(image => image.url)),
       })
-
-      test('should not find any images and create all', async () => {
-        findBySpy.mockResolvedValue([])
-        createSpy.mockReturnValue(imagesMock)
-        saveSpy.mockResolvedValue(imagesMock)
-
-        expect(
-          await imagesService.findOrCreate(sdkImagesMock, entityManagerMock)
-        ).toEqual(imagesMock)
-
-        expect(findBySpy).toHaveBeenCalledWith(Image, {
-          url: In(imagesMock.map(image => image.url)),
-        })
-        expect(createSpy).toHaveBeenCalledWith(Image, sdkImagesMock)
-        expect(saveSpy).toHaveBeenCalledWith(imagesMock)
-      })
-
-      test('should find some images and create the rest', async () => {
-        findBySpy.mockResolvedValue([imagesMock[0], imagesMock[1]])
-        createSpy.mockReturnValue([imagesMock[2]])
-        saveSpy.mockResolvedValue([imagesMock[2]])
-
-        expect(
-          await imagesService.findOrCreate(sdkImagesMock, entityManagerMock)
-        ).toEqual(imagesMock)
-
-        expect(findBySpy).toHaveBeenCalledWith(Image, {
-          url: In(imagesMock.map(image => image.url)),
-        })
-        expect(createSpy).toHaveBeenCalledWith(Image, [sdkImagesMock[2]])
-        expect(saveSpy).toHaveBeenCalledWith([imagesMock[2]])
-      })
+      expect(createSpy).toHaveBeenCalledWith(Image, [sdkImagesMock[2]])
+      expect(saveSpy).toHaveBeenCalledWith([imagesMock[2]])
     })
   })
 })

--- a/src/modules/items/images/images.service.ts
+++ b/src/modules/items/images/images.service.ts
@@ -1,64 +1,12 @@
 import { Injectable } from '@nestjs/common'
-import { DataSource, EntityManager, In } from 'typeorm'
+import { EntityManager, In } from 'typeorm'
 
-import { ImagesRepository } from './images.repository'
 import { CreateImage } from './dtos'
 import { Image } from './image.entity'
 
 @Injectable()
 export class ImagesService {
-  constructor(
-    private readonly imagesRepository: ImagesRepository,
-    private readonly dataSource: DataSource
-  ) {}
-
-  create(newImage: CreateImage) {
-    return this.imagesRepository.createImage(newImage)
-  }
-
-  public findOrCreate(data: CreateImage): Promise<Image>
-  public findOrCreate(
-    data: CreateImage[],
-    manager?: EntityManager
-  ): Promise<Image[]>
-
-  async findOrCreate(
-    data: CreateImage | CreateImage[],
-    manager?: EntityManager
-  ): Promise<Image | Image[]> {
-    if (Array.isArray(data)) {
-      if (manager) return this.findOrCreateManyInTransaction(data, manager)
-
-      return this.findOrCreateMany(data)
-    }
-
-    return this.findOrCreateOne(data)
-  }
-
-  private async findOrCreateOne(image: CreateImage) {
-    return this.dataSource.transaction(async manager => {
-      const foundImage = await manager.findOneBy(Image, {
-        url: image.url,
-      })
-
-      if (foundImage) return foundImage
-
-      const imageEntity = manager.create(Image, image)
-
-      return manager.save(imageEntity)
-    })
-  }
-
-  private async findOrCreateMany(images: CreateImage[]) {
-    if (images.length === 0) return [] as Image[]
-
-    return Promise.all(images.map(image => this.findOrCreateOne(image)))
-  }
-
-  private async findOrCreateManyInTransaction(
-    sdkImages: CreateImage[],
-    manager: EntityManager
-  ) {
+  async findOrCreate(sdkImages: CreateImage[], manager: EntityManager) {
     if (sdkImages.length === 0) return [] as Image[]
 
     const foundImages = await manager.findBy(Image, {

--- a/src/modules/items/items.service.spec.ts
+++ b/src/modules/items/items.service.spec.ts
@@ -48,13 +48,13 @@ describe('ItemsService', () => {
         {
           provide: AlbumsService,
           useValue: {
-            updateOrCreate: vi.fn(),
+            findOrCreate: vi.fn(),
           },
         },
         {
           provide: ArtistsService,
           useValue: {
-            updateOrCreate: vi.fn(),
+            findOrCreate: vi.fn(),
           },
         },
         {
@@ -98,15 +98,15 @@ describe('ItemsService', () => {
 
     describe('findOrCreateArtists', () => {
       test('should find or create artists', async () => {
-        const artistsUpdateOrCreateSpy = vi
-          .spyOn(artistsService, 'updateOrCreate')
+        const artistsFindOrCreateSpy = vi
+          .spyOn(artistsService, 'findOrCreate')
           .mockResolvedValue(artistEntitiesMock)
 
         expect(await itemsService.findOrCreate(sdkArtistsMock)).toEqual(
           artistEntitiesMock
         )
 
-        expect(artistsUpdateOrCreateSpy).toHaveBeenCalledWith(
+        expect(artistsFindOrCreateSpy).toHaveBeenCalledWith(
           sdkArtistsMock,
           entityManagerMock
         )
@@ -124,7 +124,7 @@ describe('ItemsService', () => {
       let findBySpy: MockInstance
       let findSpy: MockInstance
       let getAlbumsSpy: GetItemsMockInstance<SdkAlbum>
-      let albumsUpdateOrCreateSpy: MockInstance
+      let albumsFindOrCreateSpy: MockInstance
 
       beforeEach(() => {
         sdkAlbumsMock = Array.from({ length: 3 }, (_, index) => ({
@@ -159,7 +159,7 @@ describe('ItemsService', () => {
         findBySpy = vi.spyOn(entityManagerMock, 'findBy')
         findSpy = vi.spyOn(entityManagerMock, 'find')
         getAlbumsSpy = vi.spyOn(spotifyService.albums, 'get')
-        albumsUpdateOrCreateSpy = vi.spyOn(albumsService, 'updateOrCreate')
+        albumsFindOrCreateSpy = vi.spyOn(albumsService, 'findOrCreate')
       })
 
       describe('Same album', () => {
@@ -181,14 +181,14 @@ describe('ItemsService', () => {
             relations: tracksRelations,
           })
           expect(getAlbumsSpy).not.toHaveBeenCalled()
-          expect(albumsUpdateOrCreateSpy).not.toHaveBeenCalled()
+          expect(albumsFindOrCreateSpy).not.toHaveBeenCalled()
         })
 
         test('should not find any tracks and create all', async () => {
           findBySpy.mockResolvedValueOnce([])
           findSpy.mockResolvedValueOnce(tracksMock)
           getAlbumsSpy.mockResolvedValue(sdkAlbumsMock)
-          albumsUpdateOrCreateSpy.mockResolvedValue(albumsMock)
+          albumsFindOrCreateSpy.mockResolvedValue(albumsMock)
 
           expect(await itemsService.findOrCreate(sdkTracksMock)).toEqual(
             tracksMock
@@ -207,7 +207,7 @@ describe('ItemsService', () => {
             [sdkAlbumsMock[0].id],
             false
           )
-          expect(albumsUpdateOrCreateSpy).toHaveBeenCalledWith(
+          expect(albumsFindOrCreateSpy).toHaveBeenCalledWith(
             sdkAlbumsMock,
             entityManagerMock
           )
@@ -245,14 +245,14 @@ describe('ItemsService', () => {
             relations: tracksRelations,
           })
           expect(getAlbumsSpy).not.toHaveBeenCalled()
-          expect(albumsUpdateOrCreateSpy).not.toHaveBeenCalled()
+          expect(albumsFindOrCreateSpy).not.toHaveBeenCalled()
         })
 
         test('should not find any tracks and create all', async () => {
           findBySpy.mockResolvedValueOnce([])
           findSpy.mockResolvedValueOnce(tracksMock)
           getAlbumsSpy.mockResolvedValue(sdkAlbumsMock)
-          albumsUpdateOrCreateSpy.mockResolvedValue(albumsMock)
+          albumsFindOrCreateSpy.mockResolvedValue(albumsMock)
 
           expect(await itemsService.findOrCreate(sdkTracksMock)).toEqual(
             tracksMock
@@ -268,7 +268,7 @@ describe('ItemsService', () => {
             relations: tracksRelations,
           })
           expect(getAlbumsSpy).toHaveBeenCalledWith(externalIds, false)
-          expect(albumsUpdateOrCreateSpy).toHaveBeenCalledWith(
+          expect(albumsFindOrCreateSpy).toHaveBeenCalledWith(
             sdkAlbumsMock,
             entityManagerMock
           )
@@ -280,7 +280,7 @@ describe('ItemsService', () => {
           findBySpy.mockResolvedValueOnce(foundAlbums)
           findSpy.mockResolvedValueOnce(tracksMock)
           getAlbumsSpy.mockResolvedValue(sdkAlbumsMock.slice(2))
-          albumsUpdateOrCreateSpy.mockResolvedValue(albumsMock.slice(2))
+          albumsFindOrCreateSpy.mockResolvedValue(albumsMock.slice(2))
 
           expect(await itemsService.findOrCreate(sdkTracksMock)).toEqual(
             tracksMock
@@ -296,7 +296,7 @@ describe('ItemsService', () => {
             relations: tracksRelations,
           })
           expect(getAlbumsSpy).toHaveBeenCalledWith(externalIds.slice(2), false)
-          expect(albumsUpdateOrCreateSpy).toHaveBeenCalledWith(
+          expect(albumsFindOrCreateSpy).toHaveBeenCalledWith(
             sdkAlbumsMock.slice(2),
             entityManagerMock
           )
@@ -312,7 +312,7 @@ describe('ItemsService', () => {
 
       let findBySpy: MockInstance
       let getAlbumsSpy: GetItemsMockInstance<SdkAlbum>
-      let albumsUpdateOrCreateSpy: MockInstance
+      let albumsFindOrCreateSpy: MockInstance
 
       beforeEach(() => {
         sdkAlbumsMock = Array.from({ length: 3 }, (_, index) => ({
@@ -334,7 +334,7 @@ describe('ItemsService', () => {
 
         findBySpy = vi.spyOn(entityManagerMock, 'findBy')
         getAlbumsSpy = vi.spyOn(spotifyService.albums, 'get')
-        albumsUpdateOrCreateSpy = vi.spyOn(albumsService, 'updateOrCreate')
+        albumsFindOrCreateSpy = vi.spyOn(albumsService, 'findOrCreate')
       })
 
       test('should find all albums and does not create any', async () => {
@@ -350,13 +350,13 @@ describe('ItemsService', () => {
           externalId: In(albumsExternalIds),
         })
         expect(getAlbumsSpy).not.toHaveBeenCalled()
-        expect(albumsUpdateOrCreateSpy).not.toHaveBeenCalled()
+        expect(albumsFindOrCreateSpy).not.toHaveBeenCalled()
       })
 
       test('should not find any albums and create all', async () => {
         findBySpy.mockResolvedValueOnce([])
         getAlbumsSpy.mockResolvedValue(sdkAlbumsMock)
-        albumsUpdateOrCreateSpy.mockResolvedValue(albumsMock)
+        albumsFindOrCreateSpy.mockResolvedValue(albumsMock)
 
         expect(
           await itemsService.findOrCreate(
@@ -368,11 +368,11 @@ describe('ItemsService', () => {
           externalId: In(albumsExternalIds),
         })
         expect(getAlbumsSpy).toHaveBeenCalledWith(albumsExternalIds, false)
-        expect(albumsUpdateOrCreateSpy).toHaveBeenCalledWith(
+        expect(albumsFindOrCreateSpy).toHaveBeenCalledWith(
           sdkAlbumsMock,
           entityManagerMock
         )
-        expect(albumsUpdateOrCreateSpy).toHaveBeenCalledTimes(1)
+        expect(albumsFindOrCreateSpy).toHaveBeenCalledTimes(1)
       })
 
       test('should find some albums and create the rest', async () => {
@@ -380,7 +380,7 @@ describe('ItemsService', () => {
 
         findBySpy.mockResolvedValueOnce(foundAlbumsMock)
         getAlbumsSpy.mockResolvedValue(sdkAlbumsMock.slice(2))
-        albumsUpdateOrCreateSpy.mockResolvedValue(albumsMock.slice(2))
+        albumsFindOrCreateSpy.mockResolvedValue(albumsMock.slice(2))
 
         expect(
           await itemsService.findOrCreate(
@@ -395,11 +395,11 @@ describe('ItemsService', () => {
           albumsExternalIds.slice(2),
           false
         )
-        expect(albumsUpdateOrCreateSpy).toHaveBeenCalledWith(
+        expect(albumsFindOrCreateSpy).toHaveBeenCalledWith(
           sdkAlbumsMock.slice(2),
           entityManagerMock
         )
-        expect(albumsUpdateOrCreateSpy).toHaveBeenCalledTimes(1)
+        expect(albumsFindOrCreateSpy).toHaveBeenCalledTimes(1)
       })
     })
   })

--- a/src/modules/items/items.service.ts
+++ b/src/modules/items/items.service.ts
@@ -1,37 +1,21 @@
 import { Injectable } from '@nestjs/common'
-import { In } from 'typeorm'
+import { DataSource, In } from 'typeorm'
 
-import {
-  Album,
-  AlbumsRepository,
-  AlbumsService,
-  albumsSimplifiedRelations,
-} from './albums'
-import { Artist, ArtistsRepository, ArtistsService } from './artists'
-import { Track, TracksRepository, TracksService } from './tracks'
-import { sdkItemFilterPredicate } from './utils'
+import { Album, AlbumsService } from './albums'
+import { Artist, ArtistsService } from './artists'
+import { Track, tracksRelations } from './tracks'
 
 import { removeDuplicates } from '@common/utils'
-import { ImagesService } from '@modules/items/images'
-import {
-  SdkAlbum,
-  SdkArtist,
-  SdkSimplifiedAlbum,
-  SdkTrack,
-} from '@common/types/spotify'
+import { SdkArtist, SdkSimplifiedAlbum, SdkTrack } from '@common/types/spotify'
 import { SpotifyService } from '@modules/spotify'
 
 @Injectable()
 export class ItemsService {
   constructor(
     private readonly albumsService: AlbumsService,
-    private readonly albumsRepository: AlbumsRepository,
     private readonly artistsService: ArtistsService,
-    private readonly artistsRepository: ArtistsRepository,
-    private readonly tracksService: TracksService,
-    private readonly tracksRepository: TracksRepository,
-    private readonly imagesService: ImagesService,
-    private readonly spotifyService: SpotifyService
+    private readonly spotifyService: SpotifyService,
+    private readonly dataSource: DataSource
   ) {}
 
   public findOrCreate(tracks: SdkTrack[]): Promise<Track[]>
@@ -49,128 +33,74 @@ export class ItemsService {
       return this.findOrCreateAlbums(items as SdkSimplifiedAlbum[])
   }
 
-  private async findOrCreateArtists(artists: SdkArtist[]) {
-    const artistsExternalIds = removeDuplicates(artists.map(({ id }) => id))
-
-    const filteredArtists = await this.getFilteredArtists(artistsExternalIds)
-
-    const images = filteredArtists.flatMap(({ images }) => images)
-
-    if (images.length > 0) await this.imagesService.findOrCreate(images)
-
-    await this.artistsService.updateOrCreate(filteredArtists)
-
-    return this.artistsRepository.findArtistsByExternalIds(artistsExternalIds)
-  }
-
-  private async findOrCreateTracks(tracks: SdkTrack[]) {
-    const filteredArtists = await this.getFilteredArtists(
-      removeDuplicates(
-        tracks.flatMap(({ artists }) => artists.map(({ id }) => id))
-      )
-    )
-
-    const filteredAlbums = await this.getFilteredAlbums(
-      removeDuplicates(tracks.map(({ album }) => album.id))
-    )
-
-    const images = [
-      ...filteredArtists.flatMap(({ images }) => images),
-      ...filteredAlbums.flatMap(({ images }) => images),
-    ]
-
-    if (images.length > 0) await this.imagesService.findOrCreate(images)
-    if (filteredArtists.length > 0)
-      await this.artistsService.updateOrCreate(filteredArtists)
-    if (filteredAlbums.length > 0)
-      await this.albumsService.updateOrCreate(filteredAlbums)
-
-    return this.tracksRepository.findTracksByExternalIds(
-      removeDuplicates(tracks.map(({ id }) => id))
-    )
-  }
-
-  private async findOrCreateAlbums(fetchedAlbums: SdkSimplifiedAlbum[]) {
-    const albumsExternalIds = removeDuplicates(
-      fetchedAlbums.map(({ id }) => id)
-    )
-
-    const filteredArtists = await this.getFilteredArtists(
-      removeDuplicates(
-        fetchedAlbums.flatMap(({ artists }) => artists.map(({ id }) => id))
-      )
-    )
-
-    const filteredAlbums = await this.getFilteredAlbums(
-      removeDuplicates(fetchedAlbums.map(({ id }) => id))
-    )
-
-    const images = [
-      ...filteredArtists.flatMap(({ images }) => images),
-      ...filteredAlbums.flatMap(({ images }) => images),
-    ]
-
-    if (images.length > 0) await this.imagesService.findOrCreate(images)
-    if (filteredArtists.length > 0)
-      await this.artistsService.updateOrCreate(filteredArtists)
-    if (filteredAlbums.length > 0)
-      await this.albumsService.updateOrCreate(filteredAlbums)
-
-    return this.albumsRepository.find({
-      where: { externalId: In(albumsExternalIds) },
-      relations: albumsSimplifiedRelations,
+  private findOrCreateArtists(sdkArtists: SdkArtist[]) {
+    return this.dataSource.transaction(async manager => {
+      return this.artistsService.updateOrCreate(sdkArtists, manager)
     })
   }
 
-  private async getFilteredArtists(artistsExternalIds: string[]) {
-    const foundArtists =
-      await this.artistsRepository.findArtistsByExternalIds(artistsExternalIds)
+  private async findOrCreateTracks(tracks: SdkTrack[]) {
+    return this.dataSource.transaction(async manager => {
+      const tracksExternalIds = removeDuplicates(tracks.map(({ id }) => id))
+      const albumsExternalIds = removeDuplicates(
+        tracks.flatMap(({ album }) => album.id)
+      )
 
-    const fetchedArtists = await this.spotifyService.artists.get(
-      artistsExternalIds,
-      false
-    )
-    return fetchedArtists.filter(({ id }) =>
-      sdkItemFilterPredicate(id, foundArtists)
-    )
+      const foundAlbums = await manager.findBy(Album, {
+        externalId: In(albumsExternalIds),
+      })
+      const albumsToCreateExternalIds = albumsExternalIds.filter(
+        id => !foundAlbums.some(({ externalId }) => id === externalId)
+      )
+
+      if (albumsToCreateExternalIds.length === 0)
+        return manager.find(Track, {
+          where: {
+            externalId: In(tracksExternalIds),
+          },
+          relations: tracksRelations,
+        })
+
+      const fetchedAlbums = await this.spotifyService.albums.get(
+        albumsToCreateExternalIds,
+        false
+      )
+
+      await this.albumsService.updateOrCreate(fetchedAlbums, manager)
+
+      return manager.find(Track, {
+        where: {
+          externalId: In(tracksExternalIds),
+        },
+        relations: tracksRelations,
+      })
+    })
   }
 
-  private async getFilteredAlbums(albumsExternalIds: string[]) {
-    const fetchedAlbums = await this.spotifyService.albums.get(
-      albumsExternalIds,
-      false
-    )
-    const foundAlbums = await this.getAlbums(albumsExternalIds, fetchedAlbums)
+  private async findOrCreateAlbums(sdkAlbums: SdkSimplifiedAlbum[]) {
+    return this.dataSource.transaction(async manager => {
+      const albumsExternalIds = removeDuplicates(sdkAlbums.map(({ id }) => id))
 
-    return fetchedAlbums.filter(({ id }) =>
-      sdkItemFilterPredicate(id, foundAlbums)
-    )
-  }
+      const foundAlbums = await manager.findBy(Album, {
+        externalId: In(albumsExternalIds),
+      })
+      const albumsToCreateExternalIds = albumsExternalIds.filter(
+        id => !foundAlbums.some(({ externalId }) => id === externalId)
+      )
 
-  private async getAlbums(
-    albumsExternalIds: string[],
-    fetchedAlbums: SdkAlbum[]
-  ) {
-    const foundAlbums =
-      await this.albumsRepository.findAlbumsByExternalIds(albumsExternalIds)
+      if (albumsToCreateExternalIds.length === 0) return foundAlbums
 
-    for await (const foundAlbum of foundAlbums) {
-      if (foundAlbum.tracks?.length === 0) {
-        const fetchedAlbum = fetchedAlbums.find(
-          ({ id }) => id === foundAlbum.externalId
-        )!
+      const fetchedAlbums = await this.spotifyService.albums.get(
+        albumsToCreateExternalIds,
+        false
+      )
 
-        foundAlbum.tracks = await this.tracksService.updateOrCreate(
-          fetchedAlbum.tracks.items.map(track => ({
-            ...track,
-            album: fetchedAlbum,
-          }))
-        )
+      const createdAlbums = await this.albumsService.updateOrCreate(
+        fetchedAlbums,
+        manager
+      )
 
-        await this.albumsRepository.save(foundAlbum)
-      }
-    }
-
-    return foundAlbums
+      return [...foundAlbums, ...createdAlbums]
+    })
   }
 }

--- a/src/modules/items/items.service.ts
+++ b/src/modules/items/items.service.ts
@@ -35,7 +35,7 @@ export class ItemsService {
 
   private findOrCreateArtists(sdkArtists: SdkArtist[]) {
     return this.dataSource.transaction(async manager => {
-      return this.artistsService.updateOrCreate(sdkArtists, manager)
+      return this.artistsService.findOrCreate(sdkArtists, manager)
     })
   }
 
@@ -66,7 +66,7 @@ export class ItemsService {
         false
       )
 
-      await this.albumsService.updateOrCreate(fetchedAlbums, manager)
+      await this.albumsService.findOrCreate(fetchedAlbums, manager)
 
       return manager.find(Track, {
         where: {
@@ -95,7 +95,7 @@ export class ItemsService {
         false
       )
 
-      const createdAlbums = await this.albumsService.updateOrCreate(
+      const createdAlbums = await this.albumsService.findOrCreate(
         fetchedAlbums,
         manager
       )

--- a/src/modules/items/tracks/tracks.module.ts
+++ b/src/modules/items/tracks/tracks.module.ts
@@ -1,6 +1,8 @@
 import { Module, forwardRef } from '@nestjs/common'
 import { TypeOrmModule } from '@nestjs/typeorm'
 
+import { ArtistsModule } from '../artists'
+
 import { Track } from './track.entity'
 import { TracksRepository } from './tracks.repository'
 import { TracksController } from './tracks.controller'
@@ -14,6 +16,7 @@ import { AlbumsModule } from '@modules/items/albums'
     TypeOrmModule.forFeature([Track]),
     SpotifyModule,
     forwardRef(() => AlbumsModule),
+    ArtistsModule,
   ],
   controllers: [TracksController],
   providers: [TracksRepository, TracksService],

--- a/src/modules/items/tracks/tracks.module.ts
+++ b/src/modules/items/tracks/tracks.module.ts
@@ -1,23 +1,16 @@
-import { Module, forwardRef } from '@nestjs/common'
+import { Module } from '@nestjs/common'
 import { TypeOrmModule } from '@nestjs/typeorm'
 
-import { ArtistsModule } from '../artists'
-
 import { Track } from './track.entity'
-import { TracksRepository } from './tracks.repository'
 import { TracksController } from './tracks.controller'
+import { TracksRepository } from './tracks.repository'
 import { TracksService } from './tracks.service'
 
+import { ArtistsModule } from '@modules/items/artists'
 import { SpotifyModule } from '@modules/spotify'
-import { AlbumsModule } from '@modules/items/albums'
 
 @Module({
-  imports: [
-    TypeOrmModule.forFeature([Track]),
-    SpotifyModule,
-    forwardRef(() => AlbumsModule),
-    ArtistsModule,
-  ],
+  imports: [TypeOrmModule.forFeature([Track]), SpotifyModule, ArtistsModule],
   controllers: [TracksController],
   providers: [TracksRepository, TracksService],
   exports: [TracksRepository, TracksService],

--- a/src/modules/items/tracks/tracks.service.spec.ts
+++ b/src/modules/items/tracks/tracks.service.spec.ts
@@ -1,33 +1,21 @@
-import { Test, TestingModule } from '@nestjs/testing'
-import { DataSource, EntityManager, In } from 'typeorm'
-import { MockInstance } from 'vitest'
-import { MockProxy } from 'vitest-mock-extended'
+import { Test, type TestingModule } from '@nestjs/testing'
+import { type EntityManager, In } from 'typeorm'
+import { type MockInstance } from 'vitest'
 
 import { Track } from './track.entity'
 import { TracksService } from './tracks.service'
 
 import {
   albumEntityMock,
-  artistEntitiesMock,
   artistsMock,
   entityManagerFactoryMock,
   sdkArtistsMock,
-  sdkCreateTrackMock,
-  sdkCreateTracksMock,
   sdkSimplifiedAlbumMock,
   sdkSimplifiedArtistsMock,
   sdkSimplifiedTrackMock,
-  sdkTrackMock,
-  trackEntitiesMock,
-  trackEntityMock,
-  transactionFactoryMock,
 } from '@common/mocks'
-import {
-  EntityManagerCreateMockInstance,
-  GetItemsMockInstance,
-} from '@common/types/mocks'
-import { SdkArtist, SdkTrack } from '@common/types/spotify'
-import { Album } from '@modules/items/albums'
+import type { GetItemsMockInstance } from '@common/types/mocks'
+import type { SdkArtist, SdkTrack } from '@common/types/spotify'
 import { Artist, ArtistsService } from '@modules/items/artists'
 import { SpotifyService } from '@modules/spotify'
 
@@ -44,12 +32,6 @@ describe('TracksService', () => {
     moduleRef = await Test.createTestingModule({
       providers: [
         TracksService,
-        {
-          provide: DataSource,
-          useValue: {
-            transaction: transactionFactoryMock(entityManagerMock),
-          },
-        },
         {
           provide: ArtistsService,
           useValue: {
@@ -81,257 +63,174 @@ describe('TracksService', () => {
   })
 
   describe('updateOrCreate', () => {
-    describe('updateOrCreateOne', () => {
-      let findOneBySpy: MockInstance
+    const tracksExternalIds = ['id1', 'id2', 'id3']
+    const customSdkSimplifiedArtistsMock = sdkSimplifiedArtistsMock
+      .slice(0, 3)
+      .map((artist, index) => ({
+        ...artist,
+        id: tracksExternalIds[index],
+      }))
+    const customSdkArtistsMock = sdkArtistsMock
+      .slice(0, 3)
+      .map((artist, index) => ({
+        ...artist,
+        id: tracksExternalIds[index],
+      }))
+    const customArtistsMock = artistsMock.slice(0, 3).map((artist, index) => ({
+      externalId: tracksExternalIds[index],
+      ...artist,
+    }))
 
-      beforeEach(() => {
-        findOneBySpy = vi.spyOn(entityManagerMock, 'findOneBy')
-      })
+    let sdkTracksMock: SdkTrack[]
+    let tracksMock: Track[]
 
-      test('should update track if found', async () => {
-        findOneBySpy.mockResolvedValue(trackEntityMock)
+    let findBySpy: MockInstance
+    let createSpy: MockInstance
+    let saveSpy: MockInstance
+    let artistsUpdateOrCreateSpy: MockInstance
+    let getSpotifyArtistsSpy: GetItemsMockInstance<SdkArtist>
 
-        expect(await tracksService.updateOrCreate(sdkCreateTrackMock)).toEqual(
-          trackEntityMock
-        )
-        expect(findOneBySpy).toHaveBeenCalledWith(Track, {
-          externalId: sdkTrackMock.id,
-        })
-      })
+    beforeEach(() => {
+      sdkTracksMock = Array.from(
+        { length: 3 },
+        (_, index) =>
+          ({
+            ...sdkSimplifiedTrackMock,
+            id: tracksExternalIds[index],
+            artists: customSdkSimplifiedArtistsMock,
+            album: sdkSimplifiedAlbumMock,
+          }) as SdkTrack
+      )
+      tracksMock = Array.from(
+        { length: 3 },
+        (_, index) =>
+          ({
+            externalId: tracksExternalIds[index],
+            artists: customArtistsMock,
+            album: albumEntityMock,
+          }) as Track
+      )
 
-      test('should create track if not found', async () => {
-        findOneBySpy
-          .mockResolvedValueOnce(null)
-          .mockResolvedValue(albumEntityMock)
-        const findBySpy = vi
-          .spyOn(entityManagerMock, 'findBy')
-          .mockResolvedValue(artistEntitiesMock)
-        const createSpy = (
-          vi.spyOn(
-            entityManagerMock,
-            'create'
-          ) as EntityManagerCreateMockInstance
-        ).mockReturnValue(trackEntityMock)
-        const saveSpy = vi
-          .spyOn(entityManagerMock, 'save')
-          .mockResolvedValue(trackEntityMock)
-
-        expect(await tracksService.updateOrCreate(sdkCreateTrackMock)).toEqual(
-          trackEntityMock
-        )
-        expect(createSpy).toHaveBeenCalledWith(Track, {
-          name: sdkTrackMock.name,
-          externalId: sdkTrackMock.id,
-          href: sdkTrackMock.external_urls.spotify,
-          duration: sdkTrackMock.duration_ms,
-          trackNumber: sdkTrackMock.track_number,
-          discNumber: sdkTrackMock.disc_number,
-          explicit: sdkTrackMock.explicit,
-          album: albumEntityMock,
-          artists: artistEntitiesMock,
-        })
-        expect(saveSpy).toHaveBeenCalledWith(trackEntityMock)
-        expect(findOneBySpy).toHaveBeenCalledWith(Track, {
-          externalId: sdkTrackMock.id,
-        })
-        expect(findOneBySpy).toHaveBeenCalledWith(Album, {
-          externalId: sdkTrackMock.album.id,
-        })
-        expect(findOneBySpy).toHaveBeenCalledTimes(2)
-        expect(findBySpy).toHaveBeenCalledWith(Artist, {
-          externalId: In(
-            artistEntitiesMock.map(({ externalId }) => externalId)
-          ),
-        })
-      })
+      findBySpy = vi.spyOn(entityManagerMock, 'findBy')
+      createSpy = vi.spyOn(entityManagerMock, 'create')
+      saveSpy = vi.spyOn(entityManagerMock, 'save')
+      artistsUpdateOrCreateSpy = vi.spyOn(artistsService, 'updateOrCreate')
+      getSpotifyArtistsSpy = vi.spyOn(spotifyService.artists, 'get')
     })
 
-    describe('updateOrCreateMany', () => {
-      test('should update or create many tracks', async () => {
-        const updateOrCreateOneSpy = vi
-          .spyOn(tracksService as never, 'updateOrCreateOne')
-          .mockResolvedValue(trackEntityMock)
+    test('should find all tracks and does not create any', async () => {
+      findBySpy.mockResolvedValue(tracksMock)
 
-        expect(await tracksService.updateOrCreate(sdkCreateTracksMock)).toEqual(
-          trackEntitiesMock
+      expect(
+        await tracksService.updateOrCreate(
+          sdkTracksMock,
+          entityManagerMock,
+          albumEntityMock
         )
-        expect(updateOrCreateOneSpy).toHaveBeenCalledWith(sdkCreateTrackMock)
-        expect(updateOrCreateOneSpy).toHaveBeenCalledTimes(5)
+      ).toEqual(tracksMock)
+
+      expect(findBySpy).toHaveBeenCalledWith(Track, {
+        externalId: In(tracksExternalIds),
       })
+      expect(findBySpy).toHaveBeenCalledTimes(1)
+      expect(createSpy).not.toHaveBeenCalled()
+      expect(saveSpy).not.toHaveBeenCalled()
+      expect(artistsUpdateOrCreateSpy).not.toHaveBeenCalled()
     })
 
-    describe('updateOrCreateManyInTransaction', () => {
-      const tracksExternalIds = ['id1', 'id2', 'id3']
-      const customSdkSimplifiedArtistsMock = sdkSimplifiedArtistsMock
-        .slice(0, 3)
-        .map((artist, index) => ({
-          ...artist,
-          id: tracksExternalIds[index],
-        }))
-      const customSdkArtistsMock = sdkArtistsMock
-        .slice(0, 3)
-        .map((artist, index) => ({
-          ...artist,
-          id: tracksExternalIds[index],
-        }))
-      const customArtistsMock = artistsMock
-        .slice(0, 3)
-        .map((artist, index) => ({
-          externalId: tracksExternalIds[index],
-          ...artist,
-        }))
+    test('should not find any tracks and create all', async () => {
+      findBySpy.mockResolvedValueOnce([]).mockResolvedValue(customArtistsMock)
+      createSpy.mockImplementation((_, { externalId }) =>
+        tracksMock.find(track => track.externalId === externalId)
+      )
+      saveSpy.mockResolvedValue(tracksMock)
 
-      let sdkTracksMock: MockProxy<SdkTrack>[]
-      let tracksMock: MockProxy<Track>[]
-
-      let findBySpy: MockInstance
-      let createSpy: MockInstance
-      let saveSpy: MockInstance
-      let artistsUpdateOrCreateSpy: MockInstance
-      let getSpotifyArtistsSpy: GetItemsMockInstance<SdkArtist>
-
-      beforeEach(() => {
-        sdkTracksMock = Array.from(
-          { length: 3 },
-          (_, index) =>
-            ({
-              ...sdkSimplifiedTrackMock,
-              id: tracksExternalIds[index],
-              artists: customSdkSimplifiedArtistsMock,
-              album: sdkSimplifiedAlbumMock,
-            }) as SdkTrack
+      expect(
+        await tracksService.updateOrCreate(
+          sdkTracksMock,
+          entityManagerMock,
+          albumEntityMock
         )
-        tracksMock = Array.from(
-          { length: 3 },
-          (_, index) =>
-            ({
-              externalId: tracksExternalIds[index],
-              artists: customArtistsMock,
-              album: albumEntityMock,
-            }) as Track
-        )
+      ).toEqual(tracksMock)
 
-        findBySpy = vi.spyOn(entityManagerMock, 'findBy')
-        createSpy = vi.spyOn(entityManagerMock, 'create')
-        saveSpy = vi.spyOn(entityManagerMock, 'save')
-        artistsUpdateOrCreateSpy = vi.spyOn(artistsService, 'updateOrCreate')
-        getSpotifyArtistsSpy = vi.spyOn(spotifyService.artists, 'get')
+      expect(findBySpy).toHaveBeenCalledWith(Track, {
+        externalId: In(tracksExternalIds),
       })
-
-      test('should find all tracks and does not create any', async () => {
-        findBySpy.mockResolvedValue(tracksMock)
-
-        expect(
-          await tracksService.updateOrCreate(
-            sdkTracksMock,
-            entityManagerMock,
-            albumEntityMock
-          )
-        ).toEqual(tracksMock)
-
-        expect(findBySpy).toHaveBeenCalledWith(Track, {
-          externalId: In(tracksExternalIds),
-        })
-        expect(findBySpy).toHaveBeenCalledTimes(1)
-        expect(createSpy).not.toHaveBeenCalled()
-        expect(saveSpy).not.toHaveBeenCalled()
-        expect(artistsUpdateOrCreateSpy).not.toHaveBeenCalled()
+      expect(findBySpy).toHaveBeenCalledWith(Artist, {
+        externalId: In(tracksExternalIds),
       })
+      expect(createSpy).toHaveBeenCalledWith(Track, expect.anything())
+      expect(createSpy).toHaveBeenCalledTimes(3)
+      expect(saveSpy).toHaveBeenCalledWith(tracksMock)
+      expect(artistsUpdateOrCreateSpy).not.toHaveBeenCalled()
+    })
 
-      test('should not find any tracks and create all', async () => {
-        findBySpy.mockResolvedValueOnce([]).mockResolvedValue(customArtistsMock)
-        createSpy.mockImplementation((_, { externalId }) =>
-          tracksMock.find(track => track.externalId === externalId)
+    test('should not find any tracks and create all with some artists', async () => {
+      findBySpy
+        .mockResolvedValueOnce([])
+        .mockResolvedValue([customArtistsMock[0], customArtistsMock[1]])
+      getSpotifyArtistsSpy.mockResolvedValue([customSdkArtistsMock[2]])
+      artistsUpdateOrCreateSpy.mockResolvedValue([customArtistsMock[2]])
+      createSpy.mockImplementation((_, { externalId }) =>
+        tracksMock.find(track => track.externalId === externalId)
+      )
+      saveSpy.mockResolvedValue(tracksMock)
+
+      expect(
+        await tracksService.updateOrCreate(
+          sdkTracksMock,
+          entityManagerMock,
+          albumEntityMock
         )
-        saveSpy.mockResolvedValue(tracksMock)
+      ).toEqual(tracksMock)
 
-        expect(
-          await tracksService.updateOrCreate(
-            sdkTracksMock,
-            entityManagerMock,
-            albumEntityMock
-          )
-        ).toEqual(tracksMock)
-
-        expect(findBySpy).toHaveBeenCalledWith(Track, {
-          externalId: In(tracksExternalIds),
-        })
-        expect(findBySpy).toHaveBeenCalledWith(Artist, {
-          externalId: In(tracksExternalIds),
-        })
-        expect(createSpy).toHaveBeenCalledWith(Track, expect.anything())
-        expect(createSpy).toHaveBeenCalledTimes(3)
-        expect(saveSpy).toHaveBeenCalledWith(tracksMock)
-        expect(artistsUpdateOrCreateSpy).not.toHaveBeenCalled()
+      expect(findBySpy).toHaveBeenCalledWith(Track, {
+        externalId: In(tracksExternalIds),
       })
-
-      test('should not find any tracks and create all with some artists', async () => {
-        findBySpy
-          .mockResolvedValueOnce([])
-          .mockResolvedValue([customArtistsMock[0], customArtistsMock[1]])
-        getSpotifyArtistsSpy.mockResolvedValue([customSdkArtistsMock[2]])
-        artistsUpdateOrCreateSpy.mockResolvedValue([customArtistsMock[2]])
-        createSpy.mockImplementation((_, { externalId }) =>
-          tracksMock.find(track => track.externalId === externalId)
-        )
-        saveSpy.mockResolvedValue(tracksMock)
-
-        expect(
-          await tracksService.updateOrCreate(
-            sdkTracksMock,
-            entityManagerMock,
-            albumEntityMock
-          )
-        ).toEqual(tracksMock)
-
-        expect(findBySpy).toHaveBeenCalledWith(Track, {
-          externalId: In(tracksExternalIds),
-        })
-        expect(findBySpy).toHaveBeenCalledWith(Artist, {
-          externalId: In(tracksExternalIds),
-        })
-        expect(getSpotifyArtistsSpy).toHaveBeenCalledWith(
-          tracksExternalIds.slice(2, 3),
-          false
-        )
-        expect(artistsUpdateOrCreateSpy).toHaveBeenCalledWith(
-          customSdkArtistsMock.slice(2, 3),
-          entityManagerMock
-        )
-        expect(createSpy).toHaveBeenCalledWith(Track, expect.anything())
-        expect(createSpy).toHaveBeenCalledTimes(3)
-        expect(saveSpy).toHaveBeenCalledWith(tracksMock)
+      expect(findBySpy).toHaveBeenCalledWith(Artist, {
+        externalId: In(tracksExternalIds),
       })
+      expect(getSpotifyArtistsSpy).toHaveBeenCalledWith(
+        tracksExternalIds.slice(2, 3),
+        false
+      )
+      expect(artistsUpdateOrCreateSpy).toHaveBeenCalledWith(
+        customSdkArtistsMock.slice(2, 3),
+        entityManagerMock
+      )
+      expect(createSpy).toHaveBeenCalledWith(Track, expect.anything())
+      expect(createSpy).toHaveBeenCalledTimes(3)
+      expect(saveSpy).toHaveBeenCalledWith(tracksMock)
+    })
 
-      test('should find some tracks and create the rest', async () => {
-        findBySpy
-          .mockResolvedValueOnce([tracksMock[0], tracksMock[1]])
-          .mockResolvedValue(customArtistsMock)
-        createSpy.mockImplementation((_, { externalId }) =>
-          tracksMock.find(track => track.externalId === externalId)
+    test('should find some tracks and create the rest', async () => {
+      findBySpy
+        .mockResolvedValueOnce([tracksMock[0], tracksMock[1]])
+        .mockResolvedValue(customArtistsMock)
+      createSpy.mockImplementation((_, { externalId }) =>
+        tracksMock.find(track => track.externalId === externalId)
+      )
+      saveSpy.mockResolvedValue([tracksMock[2]])
+
+      expect(
+        await tracksService.updateOrCreate(
+          sdkTracksMock,
+          entityManagerMock,
+          albumEntityMock
         )
-        saveSpy.mockResolvedValue([tracksMock[2]])
+      ).toEqual(tracksMock)
 
-        expect(
-          await tracksService.updateOrCreate(
-            sdkTracksMock,
-            entityManagerMock,
-            albumEntityMock
-          )
-        ).toEqual(tracksMock)
-
-        expect(findBySpy).toHaveBeenCalledWith(Track, {
-          externalId: In(tracksExternalIds),
-        })
-        expect(findBySpy).toHaveBeenCalledWith(Artist, {
-          externalId: In(tracksExternalIds),
-        })
-        expect(getSpotifyArtistsSpy).not.toHaveBeenCalled()
-        expect(artistsUpdateOrCreateSpy).not.toHaveBeenCalled()
-        expect(createSpy).toHaveBeenCalledWith(Track, expect.anything())
-        expect(createSpy).toHaveBeenCalledTimes(1)
-        expect(saveSpy).toHaveBeenCalledWith([tracksMock[2]])
+      expect(findBySpy).toHaveBeenCalledWith(Track, {
+        externalId: In(tracksExternalIds),
       })
+      expect(findBySpy).toHaveBeenCalledWith(Artist, {
+        externalId: In(tracksExternalIds),
+      })
+      expect(getSpotifyArtistsSpy).not.toHaveBeenCalled()
+      expect(artistsUpdateOrCreateSpy).not.toHaveBeenCalled()
+      expect(createSpy).toHaveBeenCalledWith(Track, expect.anything())
+      expect(createSpy).toHaveBeenCalledTimes(1)
+      expect(saveSpy).toHaveBeenCalledWith([tracksMock[2]])
     })
   })
 })

--- a/src/modules/items/tracks/tracks.service.spec.ts
+++ b/src/modules/items/tracks/tracks.service.spec.ts
@@ -35,7 +35,7 @@ describe('TracksService', () => {
         {
           provide: ArtistsService,
           useValue: {
-            updateOrCreate: vi.fn(),
+            findOrCreate: vi.fn(),
           },
         },
         {
@@ -62,7 +62,7 @@ describe('TracksService', () => {
     expect(tracksService).toBeDefined()
   })
 
-  describe('updateOrCreate', () => {
+  describe('findOrCreate', () => {
     const tracksExternalIds = ['id1', 'id2', 'id3']
     const customSdkSimplifiedArtistsMock = sdkSimplifiedArtistsMock
       .slice(0, 3)
@@ -87,7 +87,7 @@ describe('TracksService', () => {
     let findBySpy: MockInstance
     let createSpy: MockInstance
     let saveSpy: MockInstance
-    let artistsUpdateOrCreateSpy: MockInstance
+    let artistsFindOrCreateSpy: MockInstance
     let getSpotifyArtistsSpy: GetItemsMockInstance<SdkArtist>
 
     beforeEach(() => {
@@ -114,7 +114,7 @@ describe('TracksService', () => {
       findBySpy = vi.spyOn(entityManagerMock, 'findBy')
       createSpy = vi.spyOn(entityManagerMock, 'create')
       saveSpy = vi.spyOn(entityManagerMock, 'save')
-      artistsUpdateOrCreateSpy = vi.spyOn(artistsService, 'updateOrCreate')
+      artistsFindOrCreateSpy = vi.spyOn(artistsService, 'findOrCreate')
       getSpotifyArtistsSpy = vi.spyOn(spotifyService.artists, 'get')
     })
 
@@ -122,7 +122,7 @@ describe('TracksService', () => {
       findBySpy.mockResolvedValue(tracksMock)
 
       expect(
-        await tracksService.updateOrCreate(
+        await tracksService.findOrCreate(
           sdkTracksMock,
           entityManagerMock,
           albumEntityMock
@@ -135,7 +135,7 @@ describe('TracksService', () => {
       expect(findBySpy).toHaveBeenCalledTimes(1)
       expect(createSpy).not.toHaveBeenCalled()
       expect(saveSpy).not.toHaveBeenCalled()
-      expect(artistsUpdateOrCreateSpy).not.toHaveBeenCalled()
+      expect(artistsFindOrCreateSpy).not.toHaveBeenCalled()
     })
 
     test('should not find any tracks and create all', async () => {
@@ -146,7 +146,7 @@ describe('TracksService', () => {
       saveSpy.mockResolvedValue(tracksMock)
 
       expect(
-        await tracksService.updateOrCreate(
+        await tracksService.findOrCreate(
           sdkTracksMock,
           entityManagerMock,
           albumEntityMock
@@ -162,7 +162,7 @@ describe('TracksService', () => {
       expect(createSpy).toHaveBeenCalledWith(Track, expect.anything())
       expect(createSpy).toHaveBeenCalledTimes(3)
       expect(saveSpy).toHaveBeenCalledWith(tracksMock)
-      expect(artistsUpdateOrCreateSpy).not.toHaveBeenCalled()
+      expect(artistsFindOrCreateSpy).not.toHaveBeenCalled()
     })
 
     test('should not find any tracks and create all with some artists', async () => {
@@ -170,14 +170,14 @@ describe('TracksService', () => {
         .mockResolvedValueOnce([])
         .mockResolvedValue([customArtistsMock[0], customArtistsMock[1]])
       getSpotifyArtistsSpy.mockResolvedValue([customSdkArtistsMock[2]])
-      artistsUpdateOrCreateSpy.mockResolvedValue([customArtistsMock[2]])
+      artistsFindOrCreateSpy.mockResolvedValue([customArtistsMock[2]])
       createSpy.mockImplementation((_, { externalId }) =>
         tracksMock.find(track => track.externalId === externalId)
       )
       saveSpy.mockResolvedValue(tracksMock)
 
       expect(
-        await tracksService.updateOrCreate(
+        await tracksService.findOrCreate(
           sdkTracksMock,
           entityManagerMock,
           albumEntityMock
@@ -194,7 +194,7 @@ describe('TracksService', () => {
         tracksExternalIds.slice(2, 3),
         false
       )
-      expect(artistsUpdateOrCreateSpy).toHaveBeenCalledWith(
+      expect(artistsFindOrCreateSpy).toHaveBeenCalledWith(
         customSdkArtistsMock.slice(2, 3),
         entityManagerMock
       )
@@ -213,7 +213,7 @@ describe('TracksService', () => {
       saveSpy.mockResolvedValue([tracksMock[2]])
 
       expect(
-        await tracksService.updateOrCreate(
+        await tracksService.findOrCreate(
           sdkTracksMock,
           entityManagerMock,
           albumEntityMock
@@ -227,7 +227,7 @@ describe('TracksService', () => {
         externalId: In(tracksExternalIds),
       })
       expect(getSpotifyArtistsSpy).not.toHaveBeenCalled()
-      expect(artistsUpdateOrCreateSpy).not.toHaveBeenCalled()
+      expect(artistsFindOrCreateSpy).not.toHaveBeenCalled()
       expect(createSpy).toHaveBeenCalledWith(Track, expect.anything())
       expect(createSpy).toHaveBeenCalledTimes(1)
       expect(saveSpy).toHaveBeenCalledWith([tracksMock[2]])

--- a/src/modules/items/tracks/tracks.service.spec.ts
+++ b/src/modules/items/tracks/tracks.service.spec.ts
@@ -1,29 +1,42 @@
 import { Test, TestingModule } from '@nestjs/testing'
-import { MockInstance } from 'vitest'
 import { DataSource, EntityManager, In } from 'typeorm'
+import { MockInstance } from 'vitest'
+import { MockProxy } from 'vitest-mock-extended'
 
-import { TracksService } from './tracks.service'
 import { Track } from './track.entity'
+import { TracksService } from './tracks.service'
 
-import { Album } from '@modules/items/albums'
-import { Artist } from '@modules/items/artists'
 import {
-  sdkTrackMock,
-  trackEntityMock,
   albumEntityMock,
   artistEntitiesMock,
+  artistsMock,
   entityManagerFactoryMock,
-  transactionFactoryMock,
+  sdkArtistsMock,
   sdkCreateTrackMock,
   sdkCreateTracksMock,
+  sdkSimplifiedAlbumMock,
+  sdkSimplifiedArtistsMock,
+  sdkSimplifiedTrackMock,
+  sdkTrackMock,
   trackEntitiesMock,
+  trackEntityMock,
+  transactionFactoryMock,
 } from '@common/mocks'
-import { EntityManagerCreateMockInstance } from '@common/types/mocks'
+import {
+  EntityManagerCreateMockInstance,
+  GetItemsMockInstance,
+} from '@common/types/mocks'
+import { SdkArtist, SdkTrack } from '@common/types/spotify'
+import { Album } from '@modules/items/albums'
+import { Artist, ArtistsService } from '@modules/items/artists'
+import { SpotifyService } from '@modules/spotify'
 
 describe('TracksService', () => {
   let moduleRef: TestingModule
   let entityManagerMock: EntityManager
   let tracksService: TracksService
+  let artistsService: ArtistsService
+  let spotifyService: SpotifyService
 
   beforeEach(async () => {
     entityManagerMock = entityManagerFactoryMock()
@@ -37,10 +50,26 @@ describe('TracksService', () => {
             transaction: transactionFactoryMock(entityManagerMock),
           },
         },
+        {
+          provide: ArtistsService,
+          useValue: {
+            updateOrCreate: vi.fn(),
+          },
+        },
+        {
+          provide: SpotifyService,
+          useValue: {
+            artists: {
+              get: vi.fn(),
+            },
+          },
+        },
       ],
     }).compile()
 
     tracksService = moduleRef.get(TracksService)
+    artistsService = moduleRef.get(ArtistsService)
+    spotifyService = moduleRef.get(SpotifyService)
   })
 
   afterEach(() => {
@@ -128,6 +157,180 @@ describe('TracksService', () => {
         )
         expect(updateOrCreateOneSpy).toHaveBeenCalledWith(sdkCreateTrackMock)
         expect(updateOrCreateOneSpy).toHaveBeenCalledTimes(5)
+      })
+    })
+
+    describe('updateOrCreateManyInTransaction', () => {
+      const tracksExternalIds = ['id1', 'id2', 'id3']
+      const customSdkSimplifiedArtistsMock = sdkSimplifiedArtistsMock
+        .slice(0, 3)
+        .map((artist, index) => ({
+          ...artist,
+          id: tracksExternalIds[index],
+        }))
+      const customSdkArtistsMock = sdkArtistsMock
+        .slice(0, 3)
+        .map((artist, index) => ({
+          ...artist,
+          id: tracksExternalIds[index],
+        }))
+      const customArtistsMock = artistsMock
+        .slice(0, 3)
+        .map((artist, index) => ({
+          externalId: tracksExternalIds[index],
+          ...artist,
+        }))
+
+      let sdkTracksMock: MockProxy<SdkTrack>[]
+      let tracksMock: MockProxy<Track>[]
+
+      let findBySpy: MockInstance
+      let createSpy: MockInstance
+      let saveSpy: MockInstance
+      let artistsUpdateOrCreateSpy: MockInstance
+      let getSpotifyArtistsSpy: GetItemsMockInstance<SdkArtist>
+
+      beforeEach(() => {
+        sdkTracksMock = Array.from(
+          { length: 3 },
+          (_, index) =>
+            ({
+              ...sdkSimplifiedTrackMock,
+              id: tracksExternalIds[index],
+              artists: customSdkSimplifiedArtistsMock,
+              album: sdkSimplifiedAlbumMock,
+            }) as SdkTrack
+        )
+        tracksMock = Array.from(
+          { length: 3 },
+          (_, index) =>
+            ({
+              externalId: tracksExternalIds[index],
+              artists: customArtistsMock,
+              album: albumEntityMock,
+            }) as Track
+        )
+
+        findBySpy = vi.spyOn(entityManagerMock, 'findBy')
+        createSpy = vi.spyOn(entityManagerMock, 'create')
+        saveSpy = vi.spyOn(entityManagerMock, 'save')
+        artistsUpdateOrCreateSpy = vi.spyOn(artistsService, 'updateOrCreate')
+        getSpotifyArtistsSpy = vi.spyOn(spotifyService.artists, 'get')
+      })
+
+      test('should find all tracks and does not create any', async () => {
+        findBySpy.mockResolvedValue(tracksMock)
+
+        expect(
+          await tracksService.updateOrCreate(
+            sdkTracksMock,
+            entityManagerMock,
+            albumEntityMock
+          )
+        ).toEqual(tracksMock)
+
+        expect(findBySpy).toHaveBeenCalledWith(Track, {
+          externalId: In(tracksExternalIds),
+        })
+        expect(findBySpy).toHaveBeenCalledTimes(1)
+        expect(createSpy).not.toHaveBeenCalled()
+        expect(saveSpy).not.toHaveBeenCalled()
+        expect(artistsUpdateOrCreateSpy).not.toHaveBeenCalled()
+      })
+
+      test('should not find any tracks and create all', async () => {
+        findBySpy.mockResolvedValueOnce([]).mockResolvedValue(customArtistsMock)
+        createSpy.mockImplementation((_, { externalId }) =>
+          tracksMock.find(track => track.externalId === externalId)
+        )
+        saveSpy.mockResolvedValue(tracksMock)
+
+        expect(
+          await tracksService.updateOrCreate(
+            sdkTracksMock,
+            entityManagerMock,
+            albumEntityMock
+          )
+        ).toEqual(tracksMock)
+
+        expect(findBySpy).toHaveBeenCalledWith(Track, {
+          externalId: In(tracksExternalIds),
+        })
+        expect(findBySpy).toHaveBeenCalledWith(Artist, {
+          externalId: In(tracksExternalIds),
+        })
+        expect(createSpy).toHaveBeenCalledWith(Track, expect.anything())
+        expect(createSpy).toHaveBeenCalledTimes(3)
+        expect(saveSpy).toHaveBeenCalledWith(tracksMock)
+        expect(artistsUpdateOrCreateSpy).not.toHaveBeenCalled()
+      })
+
+      test('should not find any tracks and create all with some artists', async () => {
+        findBySpy
+          .mockResolvedValueOnce([])
+          .mockResolvedValue([customArtistsMock[0], customArtistsMock[1]])
+        getSpotifyArtistsSpy.mockResolvedValue([customSdkArtistsMock[2]])
+        artistsUpdateOrCreateSpy.mockResolvedValue([customArtistsMock[2]])
+        createSpy.mockImplementation((_, { externalId }) =>
+          tracksMock.find(track => track.externalId === externalId)
+        )
+        saveSpy.mockResolvedValue(tracksMock)
+
+        expect(
+          await tracksService.updateOrCreate(
+            sdkTracksMock,
+            entityManagerMock,
+            albumEntityMock
+          )
+        ).toEqual(tracksMock)
+
+        expect(findBySpy).toHaveBeenCalledWith(Track, {
+          externalId: In(tracksExternalIds),
+        })
+        expect(findBySpy).toHaveBeenCalledWith(Artist, {
+          externalId: In(tracksExternalIds),
+        })
+        expect(getSpotifyArtistsSpy).toHaveBeenCalledWith(
+          tracksExternalIds.slice(2, 3),
+          false
+        )
+        expect(artistsUpdateOrCreateSpy).toHaveBeenCalledWith(
+          customSdkArtistsMock.slice(2, 3),
+          entityManagerMock
+        )
+        expect(createSpy).toHaveBeenCalledWith(Track, expect.anything())
+        expect(createSpy).toHaveBeenCalledTimes(3)
+        expect(saveSpy).toHaveBeenCalledWith(tracksMock)
+      })
+
+      test('should find some tracks and create the rest', async () => {
+        findBySpy
+          .mockResolvedValueOnce([tracksMock[0], tracksMock[1]])
+          .mockResolvedValue(customArtistsMock)
+        createSpy.mockImplementation((_, { externalId }) =>
+          tracksMock.find(track => track.externalId === externalId)
+        )
+        saveSpy.mockResolvedValue([tracksMock[2]])
+
+        expect(
+          await tracksService.updateOrCreate(
+            sdkTracksMock,
+            entityManagerMock,
+            albumEntityMock
+          )
+        ).toEqual(tracksMock)
+
+        expect(findBySpy).toHaveBeenCalledWith(Track, {
+          externalId: In(tracksExternalIds),
+        })
+        expect(findBySpy).toHaveBeenCalledWith(Artist, {
+          externalId: In(tracksExternalIds),
+        })
+        expect(getSpotifyArtistsSpy).not.toHaveBeenCalled()
+        expect(artistsUpdateOrCreateSpy).not.toHaveBeenCalled()
+        expect(createSpy).toHaveBeenCalledWith(Track, expect.anything())
+        expect(createSpy).toHaveBeenCalledTimes(1)
+        expect(saveSpy).toHaveBeenCalledWith([tracksMock[2]])
       })
     })
   })

--- a/src/modules/items/tracks/tracks.service.ts
+++ b/src/modules/items/tracks/tracks.service.ts
@@ -1,20 +1,40 @@
 import { Injectable } from '@nestjs/common'
-import { DataSource, In } from 'typeorm'
+import { DataSource, EntityManager, In } from 'typeorm'
 
 import { Track } from './track.entity'
-import { SdkCreateTrack } from './dtos'
+import { CreateTrack, SdkCreateTrack } from './dtos'
 
 import { Album } from '@modules/items/albums/album.entity'
-import { Artist } from '@modules/items/artists'
+import { Artist, ArtistsService } from '@modules/items/artists'
+import { removeDuplicates } from '@common/utils'
+import { SpotifyService } from '@modules/spotify'
 @Injectable()
 export class TracksService {
-  constructor(private readonly dataSource: DataSource) {}
+  constructor(
+    private readonly dataSource: DataSource,
+    private readonly artistsService: ArtistsService,
+    private readonly spotifyService: SpotifyService
+  ) {}
 
   public updateOrCreate(data: SdkCreateTrack): Promise<Track>
   public updateOrCreate(data: SdkCreateTrack[]): Promise<Track[]>
+  public updateOrCreate(
+    data: Omit<SdkCreateTrack, 'album'>[],
+    manager: EntityManager,
+    album: Album
+  ): Promise<Track[]>
 
-  async updateOrCreate(data: SdkCreateTrack | SdkCreateTrack[]) {
-    if (Array.isArray(data)) return this.updateOrCreateMany(data)
+  async updateOrCreate(
+    data: SdkCreateTrack | SdkCreateTrack[] | Omit<SdkCreateTrack, 'album'>[],
+    manager?: EntityManager,
+    album?: Album
+  ) {
+    if (Array.isArray(data)) {
+      if (manager && album)
+        return this.updateOrCreateManyInTransaction(data, manager, album)
+
+      return this.updateOrCreateMany(data as SdkCreateTrack[])
+    }
 
     return this.updateOrCreateOne(data)
   }
@@ -62,5 +82,83 @@ export class TracksService {
     if (tracks.length === 0) return []
 
     return Promise.all(tracks.map(track => this.updateOrCreateOne(track)))
+  }
+
+  private async updateOrCreateManyInTransaction(
+    sdkTracks: Omit<SdkCreateTrack, 'album'>[],
+    manager: EntityManager,
+    album: Album
+  ) {
+    const tracksExternalIds = removeDuplicates(sdkTracks.map(({ id }) => id))
+
+    const foundTracks = await manager.findBy(Track, {
+      externalId: In(tracksExternalIds),
+    })
+    const tracksToCreate = sdkTracks.filter(
+      ({ id }) => !foundTracks.some(({ externalId }) => id === externalId)
+    )
+
+    const tracksEntities: Track[] = []
+
+    if (tracksToCreate.length === 0) return foundTracks
+
+    for (const {
+      id,
+      name,
+      external_urls: { spotify: href },
+      duration_ms,
+      track_number,
+      disc_number,
+      explicit,
+      artists: simplifiedTrackArtists,
+    } of tracksToCreate) {
+      const artistsExternalIds = removeDuplicates(
+        simplifiedTrackArtists.map(({ id }) => id)
+      )
+
+      const foundArtists = await manager.findBy(Artist, {
+        externalId: In(artistsExternalIds),
+      })
+
+      const artists: Artist[] = [...foundArtists]
+
+      if (foundArtists.length !== artistsExternalIds.length) {
+        const artistsToCreateExternalIds = artistsExternalIds.filter(
+          id => !foundArtists.some(({ externalId }) => id === externalId)
+        )
+
+        const sdkArtistsToCreate = await this.spotifyService.artists.get(
+          artistsToCreateExternalIds,
+          false
+        )
+
+        const createdArtists = await this.artistsService.updateOrCreate(
+          sdkArtistsToCreate,
+          manager
+        )
+
+        artists.push(...createdArtists)
+      }
+
+      const trackToCreate: CreateTrack = {
+        name,
+        externalId: id,
+        href,
+        duration: duration_ms,
+        trackNumber: track_number,
+        discNumber: disc_number,
+        explicit,
+        artists,
+        album,
+      }
+
+      const trackEntity = manager.create(Track, trackToCreate)
+
+      tracksEntities.push(trackEntity)
+    }
+
+    const createdTracks = await manager.save(tracksEntities)
+
+    return [...foundTracks, ...createdTracks]
   }
 }

--- a/src/modules/items/tracks/tracks.service.ts
+++ b/src/modules/items/tracks/tracks.service.ts
@@ -15,7 +15,7 @@ export class TracksService {
     private readonly spotifyService: SpotifyService
   ) {}
 
-  async updateOrCreate(
+  async findOrCreate(
     sdkTracks: Omit<SdkCreateTrack, 'album'>[],
     manager: EntityManager,
     album: Album
@@ -63,7 +63,7 @@ export class TracksService {
           false
         )
 
-        const createdArtists = await this.artistsService.updateOrCreate(
+        const createdArtists = await this.artistsService.findOrCreate(
           sdkArtistsToCreate,
           manager
         )

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   test: {
     globals: true,
     root: './',
-    pool: 'forks',
+    pool: 'threads',
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html', 'lcov'],
@@ -35,6 +35,13 @@ export default defineConfig({
         '**/*.mjs',
       ],
       all: true,
+    },
+    deps: {
+      optimizer: {
+        ssr: {
+          enabled: true,
+        },
+      },
     },
   },
   plugins: [


### PR DESCRIPTION
closes #407 

To do:
- [x] remove unused functionalities
- [x] rename methods `updateOrCreate` -> `findOrCreate`